### PR TITLE
Update the token format

### DIFF
--- a/config/github.spc
+++ b/config/github.spc
@@ -2,7 +2,7 @@ connection "github" {
   plugin    = "github"   
 
   # The GitHub plugin uses a personal access token to authenticate 
-  # to the GitHub APIs  (it looks like `3b99b12218f63bcd702ad90d345975ef6c62f7d8`).
+  # to the GitHub APIs  (it looks like `ghp_3b99b12218f63bcd702ad90d345975ef6c62f7d8`).
   # You must create a Personal Access Token
   # (https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) 
   # and assign the following scopes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ Installing the latest aws plugin will create a config file (`~/.steampipe/config
 ```hcl
 connection "github" {
   plugin = "github"
-  token  = "111222333444555666777888999aaabbbcccddde"
+  token  = "ghp_111222333444555666777888999aaabbbcccddde"
 }
 ```
 - `token` - [Personal Access Token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) for your GitHub account.


### PR DESCRIPTION
The github token format has been updated a few month ago. I updated the example format in the config file.
