### PR TITLE
Add table github_rate_limit closes #72

### DIFF
--- a/docs/tables/github_rate_limit.md
+++ b/docs/tables/github_rate_limit.md
@@ -1,0 +1,17 @@
+# Table: github_rate_limit
+
+With the Rate Limit API, you can check the current rate limit status of various REST APIs.
+
+## Examples
+
+### List rate limit of rest apis
+
+```sql
+select
+  core_limit,
+  core_remaining,
+  search_limit,
+  search_remaining
+from
+  github_rate_limit;
+```

--- a/github/plugin.go
+++ b/github/plugin.go
@@ -32,6 +32,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"github_my_team":             tableGitHubMyTeam(),
 			"github_organization":        tableGitHubOrganization(),
 			"github_pull_request":        tableGitHubPullRequest(),
+			"github_rate_limit":          tableGitHubRateLimit(ctx),
 			"github_release":             tableGitHubRelease(ctx),
 			"github_repository":          tableGitHubRepository(),
 			"github_stargazer":           tableGitHubStargazer(ctx),

--- a/github/table_github_rate_limit.go
+++ b/github/table_github_rate_limit.go
@@ -1,0 +1,54 @@
+package github
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/go-github/v33/github"
+	"github.com/sethvargo/go-retry"
+
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+func tableGitHubRateLimit(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "github_rate_limit",
+		Description: "Rate limit of github.",
+		List: &plugin.ListConfig{
+			Hydrate: listGitHubRateLimit,
+		},
+		Columns: []*plugin.Column{
+			// Top columns
+			{Name: "core_limit", Type: proto.ColumnType_INT, Transform: transform.FromField("Core.Limit"), Description: "The number of requests per hour the client is currently limited to."},
+			{Name: "core_remaining", Type: proto.ColumnType_INT, Transform: transform.FromField("Core.Remaining"), Description: "The number of remaining requests the client can make this hour."},
+			{Name: "core_reset", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Core.Reset").Transform(convertTimestamp), Description: "The time at which the current rate limit will reset."},
+			{Name: "search_limit", Type: proto.ColumnType_INT, Transform: transform.FromField("Search.Limit"), Description: "The number of requests per hour the client is currently limited to."},
+			{Name: "search_remaining", Type: proto.ColumnType_INT, Transform: transform.FromField("Search.Remaining"), Description: "The number of remaining requests the client can make this hour."},
+			{Name: "search_reset", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Search.Reset").Transform(convertTimestamp), Description: "The time at which the current rate limit will reset."},
+		},
+	}
+}
+
+func listGitHubRateLimit(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	client := connect(ctx, d)
+	var rateLimits *github.RateLimits
+	b, err := retry.NewFibonacci(100 * time.Millisecond)
+	if err != nil {
+		return nil, err
+	}
+	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
+		var err error
+		rateLimits, _, err = client.RateLimits(ctx)
+		if _, ok := err.(*github.RateLimitError); ok {
+			return retry.RetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	d.StreamListItem(ctx, rateLimits)
+	return nil, nil
+}

--- a/github/utils.go
+++ b/github/utils.go
@@ -56,6 +56,8 @@ func convertTimestamp(ctx context.Context, input *transform.TransformData) (inte
 	switch t := input.Value.(type) {
 	case *github.Timestamp:
 		return t.Format(time.RFC3339), nil
+	case github.Timestamp:
+		return t.Format(time.RFC3339), nil
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select
  core_limit,
  core_remaining,
  search_limit,
  search_remaining
from
  github_rate_limit;
```

```
+------------+----------------+--------------+------------------+
| core_limit | core_remaining | search_limit | search_remaining |
+------------+----------------+--------------+------------------+
| 5000       | 5000           | 30           | 30               |
+------------+----------------+--------------+------------------+
```
</details>
