### PR TITLE
Update all tables that use custom retry logic to use RetryHydrate fun…

### DIFF
--- a/github/table_github_commit.go
+++ b/github/table_github_commit.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -53,30 +51,32 @@ func tableGitHubCommitList(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	fullName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
 	owner, repo := parseRepoFullName(fullName)
 
+	type ListPageResponse struct {
+		commits []*github.RepositoryCommit
+		resp    *github.Response
+	}
+
 	opts := &github.CommitsListOptions{ListOptions: github.ListOptions{PerPage: 100}}
+
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		commits, resp, err := client.Repositories.ListCommits(ctx, owner, repo, opts)
+		return ListPageResponse{
+			commits: commits,
+			resp:    resp,
+		}, err
+	}
 
 	for {
 
-		var commits []*github.RepositoryCommit
-		var resp *github.Response
-
-		b, err := retry.NewFibonacci(100 * time.Millisecond)
-		if err != nil {
-			return nil, err
-		}
-
-		err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-			var err error
-			commits, resp, err = client.Repositories.ListCommits(ctx, owner, repo, opts)
-			if _, ok := err.(*github.RateLimitError); ok {
-				return retry.RetryableError(err)
-			}
-			return nil
-		})
+		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{shouldRetryError})
 
 		if err != nil {
 			return nil, err
 		}
+
+		listResponse := listPageResponse.(ListPageResponse)
+		commits := listResponse.commits
+		resp := listResponse.resp
 
 		for _, i := range commits {
 			d.StreamListItem(ctx, i)
@@ -112,26 +112,27 @@ func tableGitHubCommitGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 
 	client := connect(ctx, d)
 
-	var detail *github.RepositoryCommit
-	var resp *github.Response
-
-	b, err := retry.NewFibonacci(100 * time.Millisecond)
-	if err != nil {
-		return detail, err
+	type GetResponse struct {
+		commit *github.RepositoryCommit
+		resp   *github.Response
 	}
 
-	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-		var err error
-		detail, resp, err = client.Repositories.GetCommit(ctx, owner, repo, sha)
-		if _, ok := err.(*github.RateLimitError); ok {
-			return retry.RetryableError(err)
-		}
-		return nil
-	})
+	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		detail, resp, err := client.Repositories.GetCommit(ctx, owner, repo, sha)
+		return GetResponse{
+			commit: detail,
+			resp:   resp,
+		}, err
+	}
+
+	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{shouldRetryError})
 
 	if err != nil {
 		return nil, err
 	}
 
-	return detail, nil
+	getResp := getResponse.(GetResponse)
+	commit := getResp.commit
+
+	return commit, nil
 }

--- a/github/table_github_gist.go
+++ b/github/table_github_gist.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 
 	pb "github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -60,27 +58,29 @@ func tableGitHubGistList(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		id = d.KeyColumnQuals["id"].GetStringValue()
 	}
 
-	var detail *github.Gist
-
-	b, err := retry.NewFibonacci(100 * time.Millisecond)
-	if err != nil {
-		return detail, err
+	type GetResponse struct {
+		gist *github.Gist
+		resp *github.Response
 	}
 
-	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-		var err error
+	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		gist, resp, err := client.Gists.Get(ctx, id)
+		return GetResponse{
+			gist: gist,
+			resp: resp,
+		}, err
+	}
 
-		detail, _, err = client.Gists.Get(ctx, id)
-		if _, ok := err.(*github.RateLimitError); ok {
-			return retry.RetryableError(err)
-		}
-		return nil
-	})
+	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{shouldRetryError})
 
 	if err != nil {
 		return nil, err
 	}
-	d.StreamListItem(ctx, detail)
+
+	getResp := getResponse.(GetResponse)
+	gist := getResp.gist
+
+	d.StreamListItem(ctx, gist)
 	return nil, nil
 }
 

--- a/github/table_github_issue.go
+++ b/github/table_github_issue.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -70,6 +68,11 @@ func tableGitHubRepositoryIssueList(ctx context.Context, d *plugin.QueryData, h 
 	owner, repo := parseRepoFullName(fullName)
 	logger.Trace("tableGitHubRepositoryIssueList", "owner", owner, "repo", repo)
 
+	type ListPageResponse struct {
+		issues []*github.Issue
+		resp   *github.Response
+	}
+
 	// TO DO - get state and other filters from the quals
 	opt := &github.IssueListByRepoOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
@@ -78,28 +81,25 @@ func tableGitHubRepositoryIssueList(ctx context.Context, d *plugin.QueryData, h 
 
 	client := connect(ctx, d)
 
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		issues, resp, err := client.Issues.ListByRepo(ctx, owner, repo, opt)
+		return ListPageResponse{
+			issues: issues,
+			resp:   resp,
+		}, err
+	}
+
 	for {
-		var issues []*github.Issue
-		var resp *github.Response
 
-		b, err := retry.NewFibonacci(100 * time.Millisecond)
-		if err != nil {
-			return nil, err
-		}
-
-		err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-			var err error
-			issues, resp, err = client.Issues.ListByRepo(ctx, owner, repo, opt)
-
-			if _, ok := err.(*github.RateLimitError); ok {
-				return retry.RetryableError(err)
-			}
-			return nil
-		})
+		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{shouldRetryError})
 
 		if err != nil {
 			return nil, err
 		}
+
+		listResponse := listPageResponse.(ListPageResponse)
+		issues := listResponse.issues
+		resp := listResponse.resp
 
 		for _, i := range issues {
 			// Only issues, not PRs (those are in the pull_request table...)
@@ -139,28 +139,29 @@ func tableGitHubRepositoryIssueGet(ctx context.Context, d *plugin.QueryData, h *
 
 	client := connect(ctx, d)
 
-	var detail *github.Issue
-	var resp *github.Response
-
-	b, err := retry.NewFibonacci(100 * time.Millisecond)
-	if err != nil {
-		return detail, err
+	type GetResponse struct {
+		issue *github.Issue
+		resp  *github.Response
 	}
 
-	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-		var err error
+	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		detail, resp, err := client.Issues.Get(ctx, owner, repo, issueNumber)
+		return GetResponse{
+			issue: detail,
+			resp:  resp,
+		}, err
+	}
 
-		detail, resp, err = client.Issues.Get(ctx, owner, repo, issueNumber)
-		if _, ok := err.(*github.RateLimitError); ok {
-			return retry.RetryableError(err)
-		}
-		return nil
-	})
+	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{shouldRetryError})
 
 	if err != nil {
 		return nil, err
 	}
-	return detail, nil
+
+	getResp := getResponse.(GetResponse)
+	issue := getResp.issue
+
+	return issue, nil
 }
 
 func repoNameQual(_ context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/github/table_github_my_gist.go
+++ b/github/table_github_my_gist.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
 
@@ -22,38 +20,34 @@ func tableGitHubMyGist() *plugin.Table {
 
 //// list ////
 func tableGitHubMyGistList(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	logger := plugin.Logger(ctx)
-
 	client := connect(ctx, d)
+
+	type ListPageResponse struct {
+		myGist []*github.Gist
+		resp   *github.Response
+	}
 
 	opt := &github.GistListOptions{ListOptions: github.ListOptions{PerPage: 100}}
 
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		myGist, resp, err := client.Gists.List(ctx, "", opt)
+		return ListPageResponse{
+			myGist: myGist,
+			resp:   resp,
+		}, err
+	}
+
 	for {
 
-		var repos []*github.Gist
-		var resp *github.Response
-
-		b, err := retry.NewFibonacci(100 * time.Millisecond)
-		if err != nil {
-			return nil, err
-		}
-
-		err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-			var err error
-			repos, resp, err = client.Gists.List(ctx, "", opt)
-			logger.Error("tableGitHubGistList", "resp", resp)
-			logger.Error("tableGitHubGistList", "repos", repos)
-			logger.Error("tableGitHubGistList", "err", err)
-
-			if _, ok := err.(*github.RateLimitError); ok {
-				return retry.RetryableError(err)
-			}
-			return nil
-		})
+		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{shouldRetryError})
 
 		if err != nil {
 			return nil, err
 		}
+
+		listResponse := listPageResponse.(ListPageResponse)
+		repos := listResponse.myGist
+		resp := listResponse.resp
 
 		for _, i := range repos {
 			d.StreamListItem(ctx, i)

--- a/github/table_github_my_repository.go
+++ b/github/table_github_my_repository.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
@@ -27,30 +25,31 @@ func tableGitHubMyRepository() *plugin.Table {
 func tableGitHubMyRepositoryList(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	client := connect(ctx, d)
 
+	type ListPageResponse struct {
+		repo []*github.Repository
+		resp *github.Response
+	}
+
 	opt := &github.RepositoryListOptions{Type: "all", ListOptions: github.ListOptions{PerPage: 100}}
+
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		repos, resp, err := client.Repositories.List(ctx, "", opt)
+		return ListPageResponse{
+			repo: repos,
+			resp: resp,
+		}, err
+	}
 
 	for {
 
-		var repos []*github.Repository
-		var resp *github.Response
-
-		b, err := retry.NewFibonacci(100 * time.Millisecond)
-		if err != nil {
-			return nil, err
-		}
-
-		err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-			var err error
-			repos, resp, err = client.Repositories.List(ctx, "", opt)
-			if _, ok := err.(*github.RateLimitError); ok {
-				return retry.RetryableError(err)
-			}
-			return nil
-		})
+		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{shouldRetryError})
 
 		if err != nil {
 			return nil, err
 		}
+		listResponse := listPageResponse.(ListPageResponse)
+		repos := listResponse.repo
+		resp := listResponse.resp
 
 		for _, i := range repos {
 			d.StreamListItem(ctx, i)

--- a/github/table_github_pull_request.go
+++ b/github/table_github_pull_request.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -96,30 +94,31 @@ func tableGitHubPullRequestList(ctx context.Context, d *plugin.QueryData, h *plu
 
 	client := connect(ctx, d)
 
+	type ListPageResponse struct {
+		pullReqs []*github.PullRequest
+		resp     *github.Response
+	}
+
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		pullReqs, resp, err := client.PullRequests.List(ctx, owner, repo, opt)
+		return ListPageResponse{
+			pullReqs: pullReqs,
+			resp:     resp,
+		}, err
+	}
+
 	for {
-		var issues []*github.PullRequest
-		var resp *github.Response
-
-		b, err := retry.NewFibonacci(100 * time.Millisecond)
-		if err != nil {
-			return nil, err
-		}
-
-		err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-			var err error
-			issues, resp, err = client.PullRequests.List(ctx, owner, repo, opt)
-
-			if _, ok := err.(*github.RateLimitError); ok {
-				return retry.RetryableError(err)
-			}
-			return nil
-		})
+		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{shouldRetryError})
 
 		if err != nil {
 			return nil, err
 		}
 
-		for _, i := range issues {
+		listResponse := listPageResponse.(ListPageResponse)
+		pullReqs := listResponse.pullReqs
+		resp := listResponse.resp
+
+		for _, i := range pullReqs {
 			d.StreamListItem(ctx, i)
 		}
 
@@ -154,28 +153,29 @@ func tableGitHubPullRequestGet(ctx context.Context, d *plugin.QueryData, h *plug
 
 	client := connect(ctx, d)
 
-	var detail *github.PullRequest
-	var resp *github.Response
-
-	b, err := retry.NewFibonacci(100 * time.Millisecond)
-	if err != nil {
-		return detail, err
+	type GetResponse struct {
+		pullReq *github.PullRequest
+		resp    *github.Response
 	}
 
-	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-		var err error
+	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		detail, resp, err := client.PullRequests.Get(ctx, owner, repo, issueNumber)
+		return GetResponse{
+			pullReq: detail,
+			resp:    resp,
+		}, err
+	}
 
-		detail, resp, err = client.PullRequests.Get(ctx, owner, repo, issueNumber)
-		if _, ok := err.(*github.RateLimitError); ok {
-			return retry.RetryableError(err)
-		}
-		return nil
-	})
+	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{shouldRetryError})
 
 	if err != nil {
 		return nil, err
 	}
-	return detail, nil
+
+	getResp := getResponse.(GetResponse)
+	pullReq := getResp.pullReq
+
+	return pullReq, nil
 }
 
 func RepoNameFromQuals(_ context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/github/table_github_stargazer.go
+++ b/github/table_github_stargazer.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -35,24 +33,30 @@ func tableGitHubStargazerList(ctx context.Context, d *plugin.QueryData, h *plugi
 	fullName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
 	owner, repo := parseRepoFullName(fullName)
 	opts := &github.ListOptions{PerPage: 100}
+
+	type ListPageResponse struct {
+		stargazers []*github.Stargazer
+		resp       *github.Response
+	}
+
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		stargazers, resp, err := client.Activity.ListStargazers(ctx, owner, repo, opts)
+		return ListPageResponse{
+			stargazers: stargazers,
+			resp:       resp,
+		}, err
+	}
+
 	for {
-		var stargazers []*github.Stargazer
-		var resp *github.Response
-		b, err := retry.NewFibonacci(100 * time.Millisecond)
+		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{shouldRetryError})
 		if err != nil {
 			return nil, err
 		}
-		err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-			var err error
-			stargazers, resp, err = client.Activity.ListStargazers(ctx, owner, repo, opts)
-			if _, ok := err.(*github.RateLimitError); ok {
-				return retry.RetryableError(err)
-			}
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
+
+		listResponse := listPageResponse.(ListPageResponse)
+		stargazers := listResponse.stargazers
+		resp := listResponse.resp
+
 		for _, i := range stargazers {
 			d.StreamListItem(ctx, i)
 		}

--- a/github/table_github_tag.go
+++ b/github/table_github_tag.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -37,24 +35,30 @@ func tableGitHubTagList(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	fullName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
 	owner, repo := parseRepoFullName(fullName)
 	opts := &github.ListOptions{PerPage: 100}
+
+	type ListPageResponse struct {
+		tags []*github.RepositoryTag
+		resp *github.Response
+	}
+
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		tags, resp, err := client.Repositories.ListTags(ctx, owner, repo, opts)
+		return ListPageResponse{
+			tags: tags,
+			resp: resp,
+		}, err
+	}
+
 	for {
-		var tags []*github.RepositoryTag
-		var resp *github.Response
-		b, err := retry.NewFibonacci(100 * time.Millisecond)
+		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{shouldRetryError})
 		if err != nil {
 			return nil, err
 		}
-		err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-			var err error
-			tags, resp, err = client.Repositories.ListTags(ctx, owner, repo, opts)
-			if _, ok := err.(*github.RateLimitError); ok {
-				return retry.RetryableError(err)
-			}
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
+
+		listResponse := listPageResponse.(ListPageResponse)
+		tags := listResponse.tags
+		resp := listResponse.resp
+
 		for _, i := range tags {
 			d.StreamListItem(ctx, i)
 		}

--- a/github/table_github_traffic_view_daily.go
+++ b/github/table_github_traffic_view_daily.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -35,24 +33,29 @@ func tableGitHubTrafficViewDailyList(ctx context.Context, d *plugin.QueryData, h
 	fullName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
 	owner, repo := parseRepoFullName(fullName)
 	opts := &github.TrafficBreakdownOptions{Per: "day"}
-	var result *github.TrafficViews
-	var resp *github.Response
-	b, err := retry.NewFibonacci(100 * time.Millisecond)
+
+	type ListResponse struct {
+		trafficViews *github.TrafficViews
+		resp         *github.Response
+	}
+
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		trafficViews, resp, err := client.Repositories.ListTrafficViews(ctx, owner, repo, opts)
+		return ListResponse{
+			trafficViews: trafficViews,
+			resp:         resp,
+		}, err
+	}
+	
+	listResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{shouldRetryError})
 	if err != nil {
 		return nil, err
 	}
-	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-		var err error
-		result, resp, err = client.Repositories.ListTrafficViews(ctx, owner, repo, opts)
-		if _, ok := err.(*github.RateLimitError); ok {
-			return retry.RetryableError(err)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	for _, i := range result.Views {
+
+	result := listResponse.(ListResponse)
+	trafficViews := result.trafficViews
+
+	for _, i := range trafficViews.Views {
 		d.StreamListItem(ctx, i)
 	}
 	return nil, nil

--- a/github/table_github_user.go
+++ b/github/table_github_user.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -80,26 +78,27 @@ func tableGitHubUserGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 
 	client := connect(ctx, d)
 
-	var detail *github.User
-	var resp *github.Response
-
-	b, err := retry.NewFibonacci(100 * time.Millisecond)
-	if err != nil {
-		return detail, err
+	type GetResponse struct {
+		user *github.User
+		resp *github.Response
 	}
 
-	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-		var err error
-		detail, resp, err = client.Users.Get(ctx, login)
-		if _, ok := err.(*github.RateLimitError); ok {
-			return retry.RetryableError(err)
-		}
-		return nil
-	})
+	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		detail, resp, err := client.Users.Get(ctx, login)
+		return GetResponse{
+			user: detail,
+			resp: resp,
+		}, err
+	}
+	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{shouldRetryError})
 
 	if err != nil {
 		return nil, err
 	}
-	d.StreamListItem(ctx, detail)
+
+	getResp := getResponse.(GetResponse)
+	user := getResp.user
+
+	d.StreamListItem(ctx, user)
 	return nil, nil
 }

--- a/github/table_github_workflow.go
+++ b/github/table_github_workflow.go
@@ -2,10 +2,8 @@ package github
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/go-github/v33/github"
-	"github.com/sethvargo/go-retry"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -50,32 +48,34 @@ func tableGitHubWorkflowList(ctx context.Context, d *plugin.QueryData, h *plugin
 	fullName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
 	owner, repo := parseRepoFullName(fullName)
 
+	type ListPageResponse struct {
+		workflows *github.Workflows
+		resp      *github.Response
+	}
+
 	opts := &github.ListOptions{PerPage: 100}
+
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		workflows, resp, err := client.Actions.ListWorkflows(ctx, owner, repo, opts)
+		return ListPageResponse{
+			workflows: workflows,
+			resp:      resp,
+		}, err
+	}
 
 	for {
 
-		var result *github.Workflows
-		var resp *github.Response
+		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{shouldRetryError})
 
-		b, err := retry.NewFibonacci(100 * time.Millisecond)
-		if err != nil {
-			return nil, err
-		}
-
-		err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-			var err error
-			result, resp, err = client.Actions.ListWorkflows(ctx, owner, repo, opts)
-			if _, ok := err.(*github.RateLimitError); ok {
-				return retry.RetryableError(err)
-			}
-			return nil
-		})
+		listResponse := listPageResponse.(ListPageResponse)
+		workflows := listResponse.workflows
+		resp := listResponse.resp
 
 		if err != nil {
 			return nil, err
 		}
 
-		for _, i := range result.Workflows {
+		for _, i := range workflows.Workflows {
 			d.StreamListItem(ctx, i)
 		}
 
@@ -109,26 +109,26 @@ func tableGitHubWorkflowGet(ctx context.Context, d *plugin.QueryData, h *plugin.
 
 	client := connect(ctx, d)
 
-	var detail *github.Workflow
-	var resp *github.Response
-
-	b, err := retry.NewFibonacci(100 * time.Millisecond)
-	if err != nil {
-		return detail, err
+	type GetResponse struct {
+		workflow *github.Workflow
+		resp     *github.Response
 	}
 
-	err = retry.Do(ctx, retry.WithMaxRetries(10, b), func(ctx context.Context) error {
-		var err error
-		detail, resp, err = client.Actions.GetWorkflowByID(ctx, owner, repo, id)
-		if _, ok := err.(*github.RateLimitError); ok {
-			return retry.RetryableError(err)
-		}
-		return nil
-	})
+	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		detail, resp, err := client.Actions.GetWorkflowByID(ctx, owner, repo, id)
+		return GetResponse{
+			workflow: detail,
+			resp:     resp,
+		}, err
+	}
 
+	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{shouldRetryError})
 	if err != nil {
 		return nil, err
 	}
 
-	return detail, nil
+	getResp := getResponse.(GetResponse)
+	workflow := getResp.workflow
+
+	return workflow, nil
 }


### PR DESCRIPTION
- table_github_branch
- table_github_commit
- table_github_gist
- table_github_gitignore
- table_github_issue
- table_github_license
- table_github_my_gist
- table_github_my_issue
- table_github_my_organization
- table_github_my_repository
- table_github_my_team
- table_github_organization
- table_github_pull_request
- table_github_rate_limit
- table_github_release
- table_github_repository
- table_github_stargazer
- table_github_tag
- table_github_traffic_view_daily
- table_github_traffic_view_weekly
- table_github_user
- table_github_workflow

# Example query results
<details>
  <summary>Results</summary>
  
```
select * from github_branch where repository_full_name = 'turbot/steampipe'
+----------------------+---------------------------------------------------------+------------------------------------------+-----------------------------------------------------------------------------
| repository_full_name | name                                                    | commit_sha                               | commit_url                                                                  
+----------------------+---------------------------------------------------------+------------------------------------------+-----------------------------------------------------------------------------
| turbot/steampipe     | 08x_sessionstate_dbpass                                 | c92f88d333d2cde09cdc54a0c02f9c43b37d15f2 | https://api.github.com/repos/turbot/steampipe/commits/c92f88d333d2cde09cdc54
| turbot/steampipe     | 0.9.0                                                   | 04820139bbed7020768e589b2b00f92a9063fc5c | https://api.github.com/repos/turbot/steampipe/commits/04820139bbed7020768e58
| turbot/steampipe     | add-canary-workflow                                     | e33bbaa59c556e2512e8680e25ca161e092fea54 | https://api.github.com/repos/turbot/steampipe/commits/e33bbaa59c556e2512e868
| turbot/steampipe     | v0.2.x                                                  | b75b18d4c016f16454507674771edbbd2eba1463 | https://api.github.com/repos/turbot/steampipe/commits/b75b18d4c016f164545076
| turbot/steampipe     | add-trimLog-function                                    | 720d38126421043d550933e0ec8b01a9565b665e | https://api.github.com/repos/turbot/steampipe/commits/720d38126421043d550933
| turbot/steampipe     | add_reflection_table_for_Steampipe_connections_505      | 07a97ee22ae390999a1c44018f1a26e56e55ea8e | https://api.github.com/repos/turbot/steampipe/commits/07a97ee22ae390999a1c44
| turbot/steampipe     | v0.3.x                                                  | 1660a19ca864153929c03791e487a4bf36476777 | https://api.github.com/repos/turbot/steampipe/commits/1660a19ca864153929c037
| turbot/steampipe     | add_yum_apt_support_595                                 | 5331f900b24ba419d312c4478b3981d7f94f57f9 | https://api.github.com/repos/turbot/steampipe/commits/5331f900b24ba419d312c4
| turbot/steampipe     | html_format_1034                                        | c6ecaf3e0e06d7c00ba279f79a200b3ac84904bc | https://api.github.com/repos/turbot/steampipe/commits/c6ecaf3e0e06d7c00ba279
| turbot/steampipe     | add-custom-paths-#573                                   | ac7e09f317f7c4238221f7af7e75e5457d0b7f16 | https://api.github.com/repos/turbot/steampipe/commits/ac7e09f317f7c4238221f7
| turbot/steampipe     | add-logs                                                | 1ead39712c312375547dbb95f5b0aca4a30cc8a4 | https://api.github.com/repos/turbot/steampipe/commits/1ead39712c312375547dbb
| turbot/steampipe     | controls-hier                                           | 514f09f028d689484d4c9e21bfcddce4eb8212e8 | https://api.github.com/repos/turbot/steampipe/commits/514f09f028d689484d4c9e
| turbot/steampipe     | connectionConfig                                        | d4a4e1892ebc7672206172ac4e8d7df822ce5b9e | https://api.github.com/repos/turbot/steampipe/commits/d4a4e1892ebc7672206172
| turbot/steampipe     | controls-queryname                                      | a89d9999aa9e1cf2a477d03150592c4f67c08c87 | https://api.github.com/repos/turbot/steampipe/commits/a89d9999aa9e1cf2a477d0
```

```
select * from github_commit where repository_full_name = 'turbot/steampipe'
+----------------------+------------------------------------------+----------------+----------------------+-----------------------------------------------------------------------------------------------
| repository_full_name | sha                                      | author_login   | author_date          | comments_url                                                                                  
+----------------------+------------------------------------------+----------------+----------------------+-----------------------------------------------------------------------------------------------
| turbot/steampipe     | 549f4a7a20d20e26e9bb48d212d85971e828b31d | kaidaguerre    | 2021-09-28T15:46:41Z | https://api.github.com/repos/turbot/steampipe/commits/549f4a7a20d20e26e9bb48d212d85971e828b31d
|                      |                                          |                |                      |                                                                                               
| turbot/steampipe     | 97b7e7a3c50278b8a6463d40e155738bd22e719e | kaidaguerre    | 2021-10-22T17:33:00Z | https://api.github.com/repos/turbot/steampipe/commits/97b7e7a3c50278b8a6463d40e155738bd22e719e
| turbot/steampipe     | 989625f8a884650b4ea4c4ac90392b6af9786b88 | pskrbasu       | 2021-10-18T14:32:26Z | https://api.github.com/repos/turbot/steampipe/commits/989625f8a884650b4ea4c4ac90392b6af9786b88
|                      |                                          |                |                      |                                                                                               
| turbot/steampipe     | 2e8e2f18965051808c39b5b45244ebf09648df97 | MichaelBurgess | 2021-10-22T19:02:37Z | https://api.github.com/repos/turbot/steampipe/commits/2e8e2f18965051808c39b5b45244ebf09648df97
|                      |                                          |                |                      |                                                                                             
```

```
select * from github_commit where repository_full_name = 'turbot/steampipe' and sha = 'd96998aaa0b9d8057d28523482f5d52b3d1a807c';
+----------------------+------------------------------------------+--------------+----------------------+-------------------------------------------------------------------------------------------------
| repository_full_name | sha                                      | author_login | author_date          | comments_url                                                                                    
+----------------------+------------------------------------------+--------------+----------------------+-------------------------------------------------------------------------------------------------
| turbot/steampipe     | d96998aaa0b9d8057d28523482f5d52b3d1a807c | binaek       | 2021-10-22T17:32:18Z | https://api.github.com/repos/turbot/steampipe/commits/d96998aaa0b9d8057d28523482f5d52b3d1a807c/c
|                      |                                          |              |                      |                                                                                                 
+----------------------+------------------------------------------+--------------+----------------------+-------------------------------------------------------------------------------------------------
```

```
select * from github_gitignore
+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------+
| name                  | source                                                                                                                                |
+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------+
| Ada                   | # Object file                                                                                                                         |
|                       | *.o                                                                                                                                   |
|                       |                                                                                                                                       |
|                       | # Ada Library Information                                                                                                             |
|                       | *.ali                                                                                                                                 |
|                       |                                                                                                                                       |
| AppceleratorTitanium  | # Build folder and log file                                                                                                           |
|                       | build/                                                                                                                                |
|                       | build.log                                                                                                                             |
|                       |                                                                                                                                       |
| ArchLinuxPackages     | *.tar                                                                                                                                 |
|                       | *.tar.*                                                                                                                               |
|                       | *.jar                                                                                                                                 |
|                       | *.exe                                                                                                                                 |
|                       | *.msi                                                                                                                                 |
|                       | *.zip                                                                                                                                 |
|                       | *.tgz                                                                                                                                 |
|                       | *.log                                                                                                                                 |
|                       | *.log.*                                                                                                                               |
|                       | *.sig                                                                                                                                 |
|                       |                                                                                                                                       |
|                       | pkg/                                                                                                                                  |
|                       | src/                                                                                                                                  |
|                       |                                                                                                                                       |
| AppEngine             | # Google App Engine generated folder                                                                                                  |
|                       | appengine-generated/                                                                                                                  |
|                       |                                                                                                                                       |
| Android               | # Built application files                                                                                                             |
|                       | *.apk                                                                                                                                 |
|                       | *.aar                                                                                                                                 |
|                       | *.ap_                                                                                                                                 |

```

```
select * from github_gitignore where name = 'Android'
+---------+--------------------------------------------------------------------------------------------------------------+
| name    | source                                                                                                       |
+---------+--------------------------------------------------------------------------------------------------------------+
| Android | # Built application files                                                                                    |
|         | *.apk                                                                                                        |
|         | *.aar                                                                                                        |
|         | *.ap_                                                                                                        |
|         | *.aab                                                                                                        |
|         |                                                                                                              |
|         | # Files for the ART/Dalvik VM                                                                                |
|         | *.dex                                                                                                        |
|         |                                                                                                              |
|         | # Java class files                                                                                           |
|         | *.class                                                                                                      |
|         |                                                                                                              |
|         | # Generated files                                                                                            |
|         | bin/                                                                                                         |
|         | gen/                                                                                                         |
|         | out/                                                                                                         |
|         | #  Uncomment the following line in case you need and you don't have the release build type files in your app |
|         | # release/                                                                                                   |
|         |                                                                                                              |
|         | # Gradle files                                                                                               |
|         | .gradle/                                                                                                     |
|         | build/                                                                                                       |
|         |                                                                                                              |
|         | # Local configuration file (sdk path, etc)                                                                   |
|         | local.properties                                                                                             |
|         |                                                                                                              |
|         | # Proguard folder generated by Eclipse                                                                       |
|         | proguard/                                                                                                    |
|         |                                                                                                              |
|         | # Log Files                                                                                                  |
|         | *.log                                                                                                        |
|         |                                                                                                              |
|         | # Android Studio Navigation editor temp files                                                                |
|         | .navigation/                                                                                                 |
|         |                                                                                                              |
|         | # Android Studio captures folder                                                                             |
|         | captures/                                                                                                    |
|         |                                                                                                              |
|         | # IntelliJ                                                                                                   |
|         | *.iml                                                                                                        |
|         | .idea/workspace.xml                                                                                          |
|         | .idea/tasks.xml                                                                                              |
|         | .idea/gradle.xml                                                                                             |
|         | .idea/assetWizardSettings.xml                                                                                |
|         | .idea/dictionaries                                                                                           |
|         | .idea/libraries                                                                                              |
|         | # Android Studio 3 in .gitignore file.                                                                       |
|         | .idea/caches                                                                                                 |
|         | .idea/modules.xml                                                                                            |
|         | # Comment next line if keeping position of elements in Navigation Editor is relevant for you                 |
|         | .idea/navEditor.xml                                                                                          |
|         |                                                                                                              |
|         | # Keystore files                                                                                             |
|         | # Uncomment the following lines if you do not want to check your keystore files in.                          |
|         | #*.jks                                                                                                       |
|         | #*.keystore                                                                                                  |
|         |                                                                                                              |
:

```

```
 select * from github_issue where repository_full_name = 'turbot/steampipe'
+----------------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
| repository_full_name | issue_number | title                                                                                                                                                             
+----------------------+--------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
| turbot/steampipe     | 1043         | can't downgrade plugin                                                                                                                                            
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
| turbot/steampipe     | 1045         | Update auto-generated export file name format                                                                                                                     
| turbot/steampipe     | 1008         | silent failure querying large github repo                                                                                                                         
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
| turbot/steampipe     | 987          | Update dependencies with security vulnerabilities                                                                                                                 
| turbot/steampipe     | 1021         | Add acceptance tests to check dynamic schema functionality through CSV plugin                                                                                     
| turbot/steampipe     | 972          | Add steampipe_reference introspection table                                                                                                                       
|                      |              |                                                                                                                                                                   
| turbot/steampipe     | 995          | Add acceptance test for connection config with options block                                                                                                      
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   
|                      |              |                                                                                                                                                                   

```

```
 select * from github_issue where repository_full_name = 'turbot/steampipe' and issue_number = '1043'
+----------------------+--------------+------------------------+--------------+--------------------+-----------------+------------------------------------------------------------------------------------
| repository_full_name | issue_number | title                  | author_login | author_association | assignee_logins | body                                                                               
+----------------------+--------------+------------------------+--------------+--------------------+-----------------+------------------------------------------------------------------------------------
| turbot/steampipe     | 1043         | can't downgrade plugin | jzendle      | NONE               | ["binaek"]      | **Describe the bug**                                                               
|                      |              |                        |              |                    |                 |                                                                                    
|                      |              |                        |              |                    |                 | aws 0.36.0 plugin appears to be broken. Queries that join against aws_ec2_instance_
|                      |              |                        |              |                    |                 |                                                                                    
|                      |              |                        |              |                    |                 | installed aws@0.34.0                                                               
|                      |              |                        |              |                    |                 |                                                                                    
|                      |              |                        |              |                    |                 | tied to remove aws@latest                                                          
|                      |              |                        |              |                    |                 |                                                                                    
|                      |              |                        |              |                    |                 | -bash-4.2$ steampipe --install-dir ~/.fop-steampipe plugin uninstall aws@latest    
|                      |              |                        |              |                    |                 | **Error: Failed to uninstall plugin 'aws@latest' - there are active connections usi
|                      |              |                        |              |                    |                 | -bash-4.2$                                                                         
|                      |              |                        |              |                    |                 |                                                                                    
|                      |              |                        |              |                    |                 |                                                                                    
|                      |              |                        |              |                    |                 |                                                                                    
|                      |              |                        |              |                    |                 |  -bash-4.2$ steampipe --install-dir ~/.fop-steampipe plugin list                   
|                      |              |                        |              |                    |                 | +--------------------------------------------------+---------+-------------+       
|                      |              |                        |              |                    |                 | | Name                                             | Version | Connections |       
|                      |              |                        |              |                    |                 | +--------------------------------------------------+---------+-------------+       
|                      |              |                        |              |                    |                 | | hub.steampipe.io/plugins/turbot/aws@0.34         | 0.34.0  |             |       
|                      |              |                        |              |                    |                 | | hub.steampipe.io/plugins/turbot/aws@0.35         | 0.35.1  |             |       
|                      |              |                        |              |                    |                 | | hub.steampipe.io/plugins/turbot/aws@latest       | 0.36.0  | aws         |       
|                      |              |                        |              |                    |                 | | hub.steampipe.io/plugins/turbot/azure@latest     | 0.18.0  | azure       |       
|                      |              |                        |              |                    |                 | | hub.steampipe.io/plugins/turbot/gcp@latest       | 0.17.0  | gcp         |       
|                      |              |                        |              |                    |                 | | hub.steampipe.io/plugins/turbot/steampipe@latest | 0.1.3   | steampipe   |       
|                      |              |                        |              |                    |                 | +--------------------------------------------------+---------+-------------+       
|                      |              |                        |              |                    |                 |                                                                                    
|                      |              |                        |              |                    |                 | **Steampipe version (`steampipe -v`)**                                             
|                      |              |                        |              |                    |                 | v0.84.0                                                                            
|                      |              |                        |              |                    |                 |                                                                                    
+----------------------+--------------+------------------------+--------------+--------------------+-----------------+------------------------------------------------------------------------------------

```

```
select * from github_license
+--------------+-----------------------------------------+--------------------------------------------------+---------------------------------------------------------------------------------------------
| spdx_id      | name                                    | html_url                                         | conditions                                                                                  
+--------------+-----------------------------------------+--------------------------------------------------+---------------------------------------------------------------------------------------------
| GPL-3.0      | GNU General Public License v3.0         | http://choosealicense.com/licenses/gpl-3.0/      | ["include-copyright","document-changes","disclose-source","same-license"]                   
| CC0-1.0      | Creative Commons Zero v1.0 Universal    | http://choosealicense.com/licenses/cc0-1.0/      | []                                                                                          
| LGPL-2.1     | GNU Lesser General Public License v2.1  | http://choosealicense.com/licenses/lgpl-2.1/     | ["include-copyright","disclose-source","document-changes","same-license--library"]          
| BSL-1.0      | Boost Software License 1.0              | http://choosealicense.com/licenses/bsl-1.0/      | ["include-copyright--source"]                                                               
| Apache-2.0   | Apache License 2.0                      | http://choosealicense.com/licenses/apache-2.0/   | ["include-copyright","document-changes"]                                                    
| AGPL-3.0     | GNU Affero General Public License v3.0  | http://choosealicense.com/licenses/agpl-3.0/     | ["include-copyright","document-changes","disclose-source","network-use-disclose","same-licen
| GPL-2.0      | GNU General Public License v2.0         | http://choosealicense.com/licenses/gpl-2.0/      | ["include-copyright","document-changes","disclose-source","same-license"]                   
| MPL-2.0      | Mozilla Public License 2.0              | http://choosealicense.com/licenses/mpl-2.0/      | ["disclose-source","include-copyright","same-license--file"]                                
| EPL-2.0      | Eclipse Public License 2.0              | http://choosealicense.com/licenses/epl-2.0/      | ["disclose-source","include-copyright","same-license"]                                      
| BSD-3-Clause | BSD 3-Clause "New" or "Revised" License | http://choosealicense.com/licenses/bsd-3-clause/ | ["include-copyright"]                                                                       
| Unlicense    | The Unlicense                           | http://choosealicense.com/licenses/unlicense/    | []                                                                                          
| MIT          | MIT License                             | http://choosealicense.com/licenses/mit/          | ["include-copyright"]                                                                       
| BSD-2-Clause | BSD 2-Clause "Simplified" License       | http://choosealicense.com/licenses/bsd-2-clause/ | ["include-copyright"]                                                                       
+--------------+-----------------------------------------+--------------------------------------------------+---------------------------------------------------------------------------------------------

```

```
> select * from github_license where key = 'gpl-3.0'
+---------+---------------------------------+---------------------------------------------+---------------------------------------------------------------------------+-----------------------------------
| spdx_id | name                            | html_url                                    | conditions                                                                | description                       
+---------+---------------------------------+---------------------------------------------+---------------------------------------------------------------------------+-----------------------------------
| GPL-3.0 | GNU General Public License v3.0 | http://choosealicense.com/licenses/gpl-3.0/ | ["include-copyright","document-changes","disclose-source","same-license"] | Permissions of this strong copylef

```

```
 select * from github_my_issue
+-----------------------------------------+--------------+------------------------------------------------------------------------------------------------------------------------------------------------
| repository_full_name                    | issue_number | title                                                                                                                                          
+-----------------------------------------+--------------+------------------------------------------------------------------------------------------------------------------------------------------------
| turbot/steampipe-plugin-aws             | 696          | Tags for ECS services are always null                                                                                                          
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
| turbot/steampipe-plugin-aws             | 692          | Add table aws_fsx_file_system                                                                                                                  
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
| turbot/steampipe-plugin-azure           | 330          | Add table azure_databox_edge_device                                                                                                            
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
| turbot/steampipe-plugin-azure           | 327          | Add table azure_kusto_cluster                                                                                                                  
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
| turbot/steampipe-plugin-azure           | 258          | Fix Integration test failed for resources                                                                                                      
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
| turbot/steampipe-plugin-github          | 82           | Modify retry logic in table_github_branch_protection  and table_github_community_profile table                                                 
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
| turbot/steampipe-plugin-azure           | 335          | Add more details of  `EncryptionProtectorProperties` in column `encryption_protector` for table azure_sql_server                               
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
|                                         |              |                                                                                                                                                
:

```

```
select * from github_my_organization
+----------+--------------------+--------------+-----------------------------+------------------------------------------------------+---------------+--------------------+---------------+---------+------
| login    | name               | type         | html_url                    | avatar_url                                           | billing_email | blog               | collaborators | company | creat
+----------+--------------------+--------------+-----------------------------+------------------------------------------------------+---------------+--------------------+---------------+---------+------
| turbot   | Turbot             | Organization | https://github.com/turbot   | https://avatars.githubusercontent.com/u/38865304?v=4 | <null>        | https://turbot.com | <null>        | <null>  | 2018-
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
| turbotio | Turbot Development | Organization | https://github.com/turbotio | https://avatars.githubusercontent.com/u/10854165?v=4 | <null>        | <null>             | <null>        | <null>  | 2015-
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
|          |                    |              |                             |                                                      |               |                    |               |         |      
+----------+--------------------+--------------+-----------------------------+------------------------------------------------------+---------------+--------------------+---------------+---------+------

```

```
select * from github_my_repository
+-------------------------------------------------+--------------+---------+--------------------------------------------------------------------+--------------------+--------------------+---------------
| full_name                                       | language     | private | html_url                                                           | allow_merge_commit | allow_rebase_merge | allow_squash_m
+-------------------------------------------------+--------------+---------+--------------------------------------------------------------------+--------------------+--------------------+---------------
| turbot/steampipe-plugin-digitalocean            | Go           | false   | https://github.com/turbot/steampipe-plugin-digitalocean            | false              | false              | true          
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
| ParthaI/steampipe-plugin-aws                    | <null>       | false   | https://github.com/ParthaI/steampipe-plugin-aws                    | true               | true               | true          
| turbot/steampipe-mod-aws-tags                   | HCL          | false   | https://github.com/turbot/steampipe-mod-aws-tags                   | true               | false              | true          
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
| turbot/steampipe                                | Go           | false   | https://github.com/turbot/steampipe                                | false              | false              | true          
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
|                                                 |              |         |                                                                    |                    |                    |               
:

```

```
 select * from github_my_team
+--------------+-----------+-----------+---------------+-------------------+---------+-----------------------------------------------------------------------------+----------------------+---------------
| organization | slug      | name      | members_count | description       | id      | members_url                                                                 | node_id              | organization_i
+--------------+-----------+-----------+---------------+-------------------+---------+-----------------------------------------------------------------------------+----------------------+---------------
| turbot       | steampipe | Steampipe | 21            |                   | 4436597 | https://api.github.com/organizations/38865304/team/4436597/members{/member} | MDQ6VGVhbTQ0MzY1OTc= | 38865304      
| turbotio     | core      | Core      | 32            | Development team. | 1273990 | https://api.github.com/organizations/10854165/team/1273990/members{/member} | MDQ6VGVhbTEyNzM5OTA= | 10854165      
+--------------+-----------+-----------+---------------+-------------------+---------+-----------------------------------------------------------------------------+----------------------+---------------

```

```
select * from github_my_team where organization_id = '38865304' and id = '4436597'
+--------------+-----------+-----------+---------------+-------------+---------+-----------------------------------------------------------------------------+----------------------+-----------------+---
| organization | slug      | name      | members_count | description | id      | members_url                                                                 | node_id              | organization_id | or
+--------------+-----------+-----------+---------------+-------------+---------+-----------------------------------------------------------------------------+----------------------+-----------------+---
| turbot       | steampipe | Steampipe | 21            |             | 4436597 | https://api.github.com/organizations/38865304/team/4436597/members{/member} | MDQ6VGVhbTQ0MzY1OTc= | 38865304        | tu
+--------------+-----------+-----------+---------------+-------------+---------+-----------------------------------------------------------------------------+----------------------+-----------------+---

```

```
select * from github_organization where login = 'turbot'
+--------+--------+--------------+---------------------------+------------------------------------------------------+---------------+--------------------+---------------+---------+----------------------
| login  | name   | type         | html_url                  | avatar_url                                           | billing_email | blog               | collaborators | company | created_at           
+--------+--------+--------------+---------------------------+------------------------------------------------------+---------------+--------------------+---------------+---------+----------------------
| turbot | Turbot | Organization | https://github.com/turbot | https://avatars.githubusercontent.com/u/38865304?v=4 | <null>        | https://turbot.com | <null>        | <null>  | 2018-04-30T17:55:30Z 
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
|        |        |              |                           |                                                      |               |                    |               |         |                      
+--------+--------+--------------+---------------------------+------------------------------------------------------+---------------+--------------------+---------------+---------+----------------------
```

```
select * from github_pull_request where repository_full_name = 'turbot/steampipe'
+----------------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+---------
| repository_full_name | issue_number | title                                                                                                                                                   | author_l
+----------------------+--------------+---------------------------------------------------------------------------------------------------------------------------------------------------------+---------
| turbot/steampipe     | 1057         | `clean up` test benchmarks from `sample_workspace` dir to a new dir(mod). closes #1056                                                                  | pskrbasu
| turbot/steampipe     | 994          | Fix connection config parsing failing if config contains options block. Closes #993                                                                     | kaidague
| turbot/steampipe     | 1055         | steampipe check all `--dry-run` displaying status summary of controls. closes #1053                                                                     | pskrbasu
| turbot/steampipe     | 1029         | Update check --progress flag to have 3 modes - on, off and auto. closes #1016                                                                           | pskrbasu
| turbot/steampipe     | 860          | Validate that all named query parameters are defined by the query params block. Closes #845                                                             | kaidague
| turbot/steampipe     | 934          | Add acceptance tests for control params. closes #928                                                                                                    | pskrbasu
| turbot/steampipe     | 893          | Add prepared statement name column to steampipe_query and steampipe_control reflection tables. Closes #890                                              | kaidague
| turbot/steampipe     | 909          | Add steampipe_variable  reflection table. Closes #859                                                                                                   | kaidague
| turbot/steampipe     | 917          | Send Steampipe metadata to plugin with connection config                                                                                                | kaidague
| turbot/steampipe     | 1000         | Fix for incorrect message from `service status` when service is not running. Closes #975                                                                | binaek  
| turbot/steampipe     | 1009         | Add workspace mod to workspace mod map - fix check all not working. Closes #1005                                                                        | kaidague
| turbot/steampipe     | 1040         | Control results should be ordered by status. Closes #465                                                                                                | kaidague
| turbot/steampipe     | 1038         | Rename 'markdown' format to 'md'                                                                                                                        | kaidague
| turbot/steampipe     | 933          | Pass connection config to get schema call 932                                                                                                           | kaidague
| turbot/steampipe     | 1002         | Add steampipe_reference introspection table                                                                                                             | kaidague
| turbot/steampipe     | 1023         | Rename database env vars                                                                                                                                | kaidague
| turbot/steampipe     | 989          | Update dependencies with security vulnerabilities. Closes #987                                                                                          | pskrbasu
| turbot/steampipe     | 954          | Add used_by column to steampipe_variables introspection table to indicate which resources reference a given variable. Closes #953                       | kaidague
| turbot/steampipe     | 1047         | Control state icons should be center-aligned in HTML export #1034.                                                                                      | MichaelB
| turbot/steampipe     | 1041         | Update markdown template                                                                                                                                | kaidague
| turbot/steampipe     | 1046         | Updates auto generated file name format for `check` exports. Closes #1045                                                                               | binaek  
|                      |              |                                                                                                                                                         |         
| turbot/steampipe     | 1037         | Update help text                                                                                                                                        | kaidague
| turbot/steampipe     | 1028         | Add acceptance test for testing steampipe check all functionality. closes #1027                                                                         | pskrbasu
| turbot/steampipe     | 1003         | Add support for dynamic plugin schema                                                                                                                   | kaidague
| turbot/steampipe     | 1054         | steampipe should not create connection config file when a specific version of a plugin is installed. closes #1052                                       | pskrbasu
| turbot/steampipe     | 903          | Fix nil pointer error when running a fully qualified query (i.e. including mod name). Closes #902                                                       | kaidague
| turbot/steampipe     | 966          | Acceptance tests for introspection table updates. Closes #962                                                                                           | pskrbasu
| turbot/steampipe     | 889          | Fix prepared statement being renamed after editing the query during interactive session. Closes #883                                                    | kaidague
| turbot/steampipe     | 1024         | Adding support for SSL certificate validation and rotation. Closes #1020                                                                                | binaek  
| turbot/steampipe     | 956          | rename to session data - fix bug                                                                                                                        | kaidague
| turbot/steampipe     | 1033         | `markdown` output format. Closes #1011                                                                                                                  | binaek  
| turbot/steampipe     | 918          | Send Steampipe metadata to plugin with connection config #917                                                                                           | kaidague
| turbot/steampipe     | 1015         | If connection state file parsing fails, just return an empty state file to force a connection refresh. closes #1014                                     | pskrbasu
| turbot/steampipe     | 977          | Support json connection config. Closes #969                                                                                                             | kaidague
| turbot/steampipe     | 1030         | Delete accidentally added files                                                                                                                         | kaidague
| turbot/steampipe     | 922          | Update dependencies                                                                                                                                     | kaidague
| turbot/steampipe     | 988          | Support for setting a custom database name. Closes #936                                                                                                 | binaek  
| turbot/steampipe     | 1022         | Add acceptance tests to check dynamic schema functionality through CSV plugin. closes #1021                                                             | pskrbasu
| turbot/steampipe     | 997          | Add acceptance test to test time to query a chaos table that does not exist. closes #996                                                                | pskrbasu
| turbot/steampipe     | 1031         | Update control summary - only show severity block if there are high/critical items                                                                      | kaidague
| turbot/steampipe     | 999          | Add acceptance test for connection config with options block. closes #995                                                                               | pskrbasu
| turbot/steampipe     | 985          | Fix for `plugin list` `panic`. Closes #984                                                                                                              | binaek  
| turbot/steampipe     | 1036         | Updates to `html` output format. Closes #1034                                                                                                           | binaek  
| turbot/steampipe     | 1026         | Ensure plugin connection config is consistently ordered. Closes #1025                                                                                   | kaidague
| turbot/steampipe     | 978          | Support installation and resolution of mod dependencies                                                                                                 | kaidague
| turbot/steampipe     | 900          | Adds support for outputting `stdout` and `stderr` from `service start` to `TRACE log`. Closes #810                                                      | binaek  
| turbot/steampipe     | 899          | Fix issue where `service stop` shuts down service even if non-steampipe clients are connected. Closes #887                                              | binaek  
| turbot/steampipe     | 1018         | Provide mechanism to force a connection refresh #1017                                                                                                   | kaidague
| turbot/steampipe     | 958          | Add support for rotating service password in Docker images. Closes #957                                                                                 | binaek  
```

```
 select * from github_pull_request where repository_full_name = 'turbot/steampipe' and issue_number = '1026'
+----------------------+--------------+-----------------------------------------------------------------------+--------------+-----------------+-----------+--------------------+--------+---------------+
| repository_full_name | issue_number | title                                                                 | author_login | assignee_logins | additions | author_association | body   | changed_files |
+----------------------+--------------+-----------------------------------------------------------------------+--------------+-----------------+-----------+--------------------+--------+---------------+
| turbot/steampipe     | 1026         | Ensure plugin connection config is consistently ordered. Closes #1025 | kaidaguerre  | []              | 15        | MEMBER             | <null> | 2             |
+----------------------+--------------+-----------------------------------------------------------------------+--------------+-----------------+-----------+--------------------+--------+---------------+

```

```
select * from github_rate_limit
+------------+----------------+----------------------+--------------+------------------+----------------------+
| core_limit | core_remaining | core_reset           | search_limit | search_remaining | search_reset         |
+------------+----------------+----------------------+--------------+------------------+----------------------+
| 5000       | 3332           | 2021-10-26T13:44:07Z | 30           | 30               | 2021-10-26T13:05:00Z |
+------------+----------------+----------------------+--------------+------------------+----------------------+

```

```
 select * from github_release where repository_full_name = 'turbot/steampipe'
+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| repository_full_name | assets                                                                                                                                                                           
+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| turbot/steampipe     | [{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/v0.8.3/checksums.txt","content_type":"text/plain; charset=utf-8","created_at":"2021-09-28T16:02:3
|                      | api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_url":"https://
|                      | owers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}","gists_
|                      | "https://github.com/turbot/steampipe/releases/download/v0.8.3/steampipe_linux_amd64.tar.gz","content_type":"application/gzip","created_at":"2021-09-28T16:02:37Z","download_count
|                      | /api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_url":"https:/
| turbot/steampipe     | [{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/v0.8.1-rc.0/checksums.txt","content_type":"text/plain; charset=utf-8","created_at":"2021-09-10T13
|                      | ps://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_url":"htt
|                      | y}","followers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}
|                      | oad_url":"https://github.com/turbot/steampipe/releases/download/v0.8.1-rc.0/steampipe_linux_amd64.tar.gz","content_type":"application/gzip","created_at":"2021-09-10T13:18:32Z","
|                      | url":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_
| turbot/steampipe     | [{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/v0.7.1-rc.0/checksums.txt","content_type":"text/plain; charset=utf-8","created_at":"2021-07-26T16
|                      | nts_url":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"star
|                      | ns%5Bbot%5D/events{/privacy}","followers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot
|                      | 41049297"},{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/v0.7.1-rc.0/steampipe_linux_amd64.tar.gz","content_type":"application/gzip","created_at
|                      | -actions%5Bbot%5D/orgs","received_events_url":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bb
| turbot/steampipe     | [{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/v0.6.2/checksums.txt","content_type":"text/plain; charset=utf-8","created_at":"2021-07-08T20:41:0
|                      | rl":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_u
|                      | %5D/events{/privacy}","followers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/foll
|                      | "},{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/v0.6.2/steampipe_linux_amd64.tar.gz","content_type":"application/gzip","created_at":"2021-07-08
|                      | t%5D/orgs","received_events_url":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos",
| turbot/steampipe     | [{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/0.5.1/checksums.txt","content_type":"text/plain; charset=utf-8","created_at":"2021-05-27T20:20:50
|                      | l":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_ur
|                      | D/events{/privacy}","followers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/follow
|                      | ,{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/0.5.1/steampipe_linux_amd64.tar.gz","content_type":"application/gzip","created_at":"2021-05-27T20
|                      | D/orgs","received_events_url":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","si
| turbot/steampipe     | [{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/v0.9.0-rc.1/checksums.txt","content_type":"text/plain; charset=utf-8","created_at":"2021-10-20T16
|                      | ps://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_url":"htt
|                      | cy}","followers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user
|                      | load_url":"https://github.com/turbot/steampipe/releases/download/v0.9.0-rc.1/steampipe_linux_amd64.tar.gz","content_type":"application/gzip","created_at":"2021-10-20T16:22:43Z",
|                      | _url":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred
| turbot/steampipe     | [{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/v0.8.1/checksums.txt","content_type":"text/plain; charset=utf-8","created_at":"2021-09-12T20:05:0
|                      | api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_url":"https://
|                      | lowers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}","gists
|                      | :"https://github.com/turbot/steampipe/releases/download/v0.8.1/steampipe_linux_amd64.tar.gz","content_type":"application/gzip","created_at":"2021-09-12T20:05:00Z","download_coun

```

```
 select * from github_release where repository_full_name = 'turbot/steampipe' and id = '50409941'
+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| repository_full_name | assets                                                                                                                                                                           
+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| turbot/steampipe     | [{"browser_download_url":"https://github.com/turbot/steampipe/releases/download/v0.8.3/checksums.txt","content_type":"text/plain; charset=utf-8","created_at":"2021-09-28T16:02:3
|                      | api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_url":"https://
|                      | owers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}","gists_
|                      | "https://github.com/turbot/steampipe/releases/download/v0.8.3/steampipe_linux_amd64.tar.gz","content_type":"application/gzip","created_at":"2021-09-28T16:02:37Z","download_count
|                      | /api.github.com/users/github-actions%5Bbot%5D/received_events","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","site_admin":false,"starred_url":"https:/
+----------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```

```
select * from github_repository where full_name = 'turbotio/turbot-mods'
+----------------------+------------+---------+-----------------------------------------+--------------------+--------------------+--------------------+----------+---------------------------------------
| full_name            | language   | private | html_url                                | allow_merge_commit | allow_rebase_merge | allow_squash_merge | archived | clone_url                             
+----------------------+------------+---------+-----------------------------------------+--------------------+--------------------+--------------------+----------+---------------------------------------
| turbotio/turbot-mods | JavaScript | true    | https://github.com/turbotio/turbot-mods | false              | false              | true               | false    | https://github.com/turbotio/turbot-mod
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
|                      |            |         |                                         |                    |                    |                    |          |                                       
+----------------------+------------+---------+-----------------------------------------+--------------------+--------------------+--------------------+----------+---------------------------------------
(END)


```

```
select * from github_stargazer where repository_full_name = 'turbot/steampipe'
+----------------------+----------------------+-----------------------+
| repository_full_name | starred_at           | user_login            |
+----------------------+----------------------+-----------------------+
| turbot/steampipe     | 2021-01-21T00:43:33Z | bob-bot               |
| turbot/steampipe     | 2021-01-25T15:41:08Z | thaeli                |
| turbot/steampipe     | 2021-01-29T13:58:12Z | debabrat-git          |
| turbot/steampipe     | 2021-02-02T13:20:23Z | abhiturbot            |
| turbot/steampipe     | 2021-01-29T21:17:19Z | cdcutler              |
| turbot/steampipe     | 2021-01-29T09:58:42Z | tyagiparth            |
| turbot/steampipe     | 2021-01-25T13:29:20Z | couplebits            |
| turbot/steampipe     | 2021-01-31T15:20:55Z | yourpropertyexpert    |
| turbot/steampipe     | 2021-01-22T07:21:09Z | siddharthaturbot      |
| turbot/steampipe     | 2021-02-26T09:54:19Z | ormanli               |
| turbot/steampipe     | 2021-01-29T21:49:28Z | mzazon                |
| turbot/steampipe     | 2021-01-25T15:41:41Z | gkze                  |
| turbot/steampipe     | 2021-01-21T18:40:40Z | gatspy                |
| turbot/steampipe     | 2021-01-25T17:52:11Z | alexraskin            |
| turbot/steampipe     | 2021-02-03T03:45:46Z | brian-villanueva      |
| turbot/steampipe     | 2021-01-21T19:06:55Z | kapow77               |
| turbot/steampipe     | 2021-02-21T17:38:12Z | Jackneill             |
| turbot/steampipe     | 2021-01-29T12:46:44Z | chgangaraju           |
| turbot/steampipe     | 2021-02-11T20:56:00Z | jinroh                |
| turbot/steampipe     | 2021-01-21T19:07:19Z | RupeshPatil20         |
| turbot/steampipe     | 2021-01-25T15:55:56Z | karlskidmore          |
| turbot/steampipe     | 2021-02-11T21:58:26Z | JesseTG               |
| turbot/steampipe     | 2021-02-04T07:12:33Z | pskrbasu              |
| turbot/steampipe     | 2021-01-21T19:07:29Z | e-gineer              |
| turbot/steampipe     | 2021-02-11T22:26:00Z | wolfeidau             |
| turbot/steampipe     | 2021-02-11T21:08:11Z | jakejscott            |
| turbot/steampipe     | 2021-02-12T12:36:57Z | mracos                |
| turbot/steampipe     | 2021-01-21T19:07:54Z | johnsmyth             |
| turbot/steampipe     | 2021-02-04T19:33:31Z | mikesprague           |
| turbot/steampipe     | 2021-02-12T12:44:43Z | cocoonkid             |
| turbot/steampipe     | 2021-01-25T11:45:34Z | Villux                |
| turbot/steampipe     | 2021-02-11T21:11:31Z | markuman              |
| turbot/steampipe     | 2021-01-21T19:08:20Z | Rohitturbot           |
| turbot/steampipe     | 2021-01-25T18:51:56Z | spasam                |
| turbot/steampipe     | 2021-02-05T05:24:05Z | jmanteau              |
| turbot/steampipe     | 2021-02-11T22:30:35Z | bevel-zgates          |

```

```
select * from github_tag where repository_full_name = 'turbot/steampipe'
+----------------------+------------------------+------------------------------------------+------------------------------------------------------------------------------------------------+-------------
| repository_full_name | name                   | commit_sha                               | commit_url                                                                                     | zipball_url 
+----------------------+------------------------+------------------------------------------+------------------------------------------------------------------------------------------------+-------------
| turbot/steampipe     | v0.9.0-dev.1           | c25a9b76a1351de5a83e4d821c8a1d8604268196 | https://api.github.com/repos/turbot/steampipe/commits/c25a9b76a1351de5a83e4d821c8a1d8604268196 | https://api.
| turbot/steampipe     | v0.9.0-rc.1            | 6607f7d90faab61aa67606a6aa3c3af345f1e494 | https://api.github.com/repos/turbot/steampipe/commits/6607f7d90faab61aa67606a6aa3c3af345f1e494 | https://api.
| turbot/steampipe     | v0.9.0-rc.0            | 695b2704a4c160b72da43df08d11f5cc3cc8903a | https://api.github.com/repos/turbot/steampipe/commits/695b2704a4c160b72da43df08d11f5cc3cc8903a | https://api.
| turbot/steampipe     | v0.7.1                 | d2c9cb1566ec2139f090ef1ecac783cab1fe3ee9 | https://api.github.com/repos/turbot/steampipe/commits/d2c9cb1566ec2139f090ef1ecac783cab1fe3ee9 | https://api.
| turbot/steampipe     | v1.7.0-rc.0            | 504cc2f5e599a0f599fc36a7f8e4cd9f9f555110 | https://api.github.com/repos/turbot/steampipe/commits/504cc2f5e599a0f599fc36a7f8e4cd9f9f555110 | https://api.
| turbot/steampipe     | v0.9.0                 | 97b7e7a3c50278b8a6463d40e155738bd22e719e | https://api.github.com/repos/turbot/steampipe/commits/97b7e7a3c50278b8a6463d40e155738bd22e719e | https://api.
| turbot/steampipe     | v0.9.0-tx-hang.debug.1 | 9525556dc9c4c07cd42b4c79c5b62bb20eaaadda | https://api.github.com/repos/turbot/steampipe/commits/9525556dc9c4c07cd42b4c79c5b62bb20eaaadda | https://api.
| turbot/steampipe     | v0.8.4                 | 37f2b787b6c968083c2e6542508895992df7b8a2 | https://api.github.com/repos/turbot/steampipe/commits/37f2b787b6c968083c2e6542508895992df7b8a2 | https://api.
| turbot/steampipe     | v0.9.0-dev.2           | a826f9fc0171a54b704c29503f7aa6f2f393e087 | https://api.github.com/repos/turbot/steampipe/commits/a826f9fc0171a54b704c29503f7aa6f2f393e087 | https://api.
| turbot/steampipe     | v0.6.1                 | 70962e1f3dabad358f61a2dc35087449dd41c61d | https://api.github.com/repos/turbot/steampipe/commits/70962e1f3dabad358f61a2dc35087449dd41c61d | https://api.
| turbot/steampipe     | v0.8.1-rc.0            | e1b9fcbd51ceb16e1606a97f90633cc9f93f556d | https://api.github.com/repos/turbot/steampipe/commits/e1b9fcbd51ceb16e1606a97f90633cc9f93f556d | https://api.
| turbot/steampipe     | v0.4.0-rc.1            | aedb0a2d38c2771a893e8cf8130dc00bf0ab13c2 | https://api.github.com/repos/turbot/steampipe/commits/aedb0a2d38c2771a893e8cf8130dc00bf0ab13c2 | https://api.
| turbot/steampipe     | v0.6.0                 | 9c35b58137d8266d92007e6c12bd47757a1711ce | https://api.github.com/repos/turbot/steampipe/commits/9c35b58137d8266d92007e6c12bd47757a1711ce | https://api.
| turbot/steampipe     | v0.2.5                 | b75b18d4c016f16454507674771edbbd2eba1463 | https://api.github.com/repos/turbot/steampipe/commits/b75b18d4c016f16454507674771edbbd2eba1463 | https://api.
| turbot/steampipe     | v0.8.2                 | 07fc3a9dc97dd0dba27c9b218830b55c29da7ef7 | https://api.github.com/repos/turbot/steampipe/commits/07fc3a9dc97dd0dba27c9b218830b55c29da7ef7 | https://api.
| turbot/steampipe     | v0.8.0                 | 1cf5a82b7d4f9b7b455b7445a921ee061cfb8d6c | https://api.github.com/repos/turbot/steampipe/commits/1cf5a82b7d4f9b7b455b7445a921ee061cfb8d6c | https://api.
| turbot/steampipe     | v0.5.0                 | 5ae454bbde5b031a883aeed955aa7e33e04efab7 | https://api.github.com/repos/turbot/steampipe/commits/5ae454bbde5b031a883aeed955aa7e33e04efab7 | https://api.

```

```
select * from github_traffic_view_daily where repository_full_name = 'turbot/steampipe'
+----------------------+----------------------+-------+---------+
| repository_full_name | timestamp            | count | uniques |
+----------------------+----------------------+-------+---------+
| turbot/steampipe     | 2021-10-24T00:00:00Z | 39    | 12      |
| turbot/steampipe     | 2021-10-26T00:00:00Z | 14    | 6       |
| turbot/steampipe     | 2021-10-14T00:00:00Z | 214   | 70      |
| turbot/steampipe     | 2021-10-25T00:00:00Z | 67    | 29      |
| turbot/steampipe     | 2021-10-13T00:00:00Z | 159   | 33      |
| turbot/steampipe     | 2021-10-23T00:00:00Z | 23    | 13      |
| turbot/steampipe     | 2021-10-21T00:00:00Z | 294   | 12      |
| turbot/steampipe     | 2021-10-19T00:00:00Z | 554   | 44      |
| turbot/steampipe     | 2021-10-17T00:00:00Z | 32    | 21      |
| turbot/steampipe     | 2021-10-16T00:00:00Z | 75    | 26      |
| turbot/steampipe     | 2021-10-18T00:00:00Z | 357   | 31      |
| turbot/steampipe     | 2021-10-15T00:00:00Z | 78    | 35      |
| turbot/steampipe     | 2021-10-12T00:00:00Z | 49    | 12      |
| turbot/steampipe     | 2021-10-22T00:00:00Z | 547   | 23      |
| turbot/steampipe     | 2021-10-20T00:00:00Z | 182   | 23      |
+----------------------+----------------------+-------+---------+

```

```
select * from github_traffic_view_weekly where repository_full_name = 'turbot/steampipe'
+----------------------+----------------------+-------+---------+
| repository_full_name | timestamp            | count | uniques |
+----------------------+----------------------+-------+---------+
| turbot/steampipe     | 2021-10-18T00:00:00Z | 1996  | 121     |
| turbot/steampipe     | 2021-10-11T00:00:00Z | 607   | 168     |
| turbot/steampipe     | 2021-10-25T00:00:00Z | 81    | 35      |
+----------------------+----------------------+-------+---------+
```

```
select * from github_user where login = 'ParthaI'
+---------+----------+----------------------+------------------------------------------------------+----------------------------+-------------+--------+---------+------+----------+--------+----------+--
| login   | id       | node_id              | avatar_url                                           | html_url                   | gravatar_id | name   | company | blog | location | email  | hireable | b
+---------+----------+----------------------+------------------------------------------------------+----------------------------+-------------+--------+---------+------+----------+--------+----------+--
| ParthaI | 47887552 | MDQ6VXNlcjQ3ODg3NTUy | https://avatars.githubusercontent.com/u/47887552?v=4 | https://github.com/ParthaI |             | <null> | <null>  |      | <null>   | <null> | <null>   | <
+---------+----------+----------------------+------------------------------------------------------+----------------------------+-------------+--------+---------+------+----------+--------+----------+--

```

```
select * from github_workflow where repository_full_name = 'turbot/steampipe'
+----------------------+----------------------------+----------+---------------------------------------+--------------------------------------------------------------------------------------------+-----
| repository_full_name | name                       | id       | path                                  | badge_url                                                                                  | crea
+----------------------+----------------------------+----------+---------------------------------------+--------------------------------------------------------------------------------------------+-----
| turbot/steampipe     | Canary Release             | 7547431  | .github/workflows/canary.yml          | https://github.com/turbot/steampipe/workflows/Canary%20Release/badge.svg                   | 2021
| turbot/steampipe     | Build and Publish DB Image | 5127405  | .github/workflows/buildDBImage.yml    | https://github.com/turbot/steampipe/workflows/Build%20and%20Publish%20DB%20Image/badge.svg | 2021
| turbot/steampipe     | Publish Docker Release     | 11625981 | .github/workflows/publish_docker.yml  | https://github.com/turbot/steampipe/workflows/Publish%20Docker%20Release/badge.svg         | 2021
| turbot/steampipe     | Steampipe Publish Release  | 11621309 | .github/workflows/publish-release.yml | https://github.com/turbot/steampipe/workflows/Steampipe%20Publish%20Release/badge.svg      | 2021
| turbot/steampipe     | Steampipe Acceptance Tests | 5127408  | .github/workflows/test.yml            | https://github.com/turbot/steampipe/workflows/Steampipe%20Acceptance%20Tests/badge.svg     | 2021
| turbot/steampipe     | Steampipe Release          | 5127407  | .github/workflows/release.yml         | https://github.com/turbot/steampipe/workflows/Steampipe%20Release/badge.svg                | 2021
+----------------------+----------------------------+----------+---------------------------------------+--------------------------------------------------------------------------------------------+-----

```

```
select * from github_workflow where repository_full_name = 'turbot/steampipe' and id = '7547431'
+----------------------+----------------+---------+------------------------------+--------------------------------------------------------------------------+----------------------+----------------------
| repository_full_name | name           | id      | path                         | badge_url                                                                | created_at           | html_url             
+----------------------+----------------+---------+------------------------------+--------------------------------------------------------------------------+----------------------+----------------------
| turbot/steampipe     | Canary Release | 7547431 | .github/workflows/canary.yml | https://github.com/turbot/steampipe/workflows/Canary%20Release/badge.svg | 2021-04-06T07:50:30Z | https://github.com/tu
+----------------------+----------------+---------+------------------------------+--------------------------------------------------------------------------+----------------------+----------------------

```

</details>
