### PR TITLE
Fix table github_repository collaborators not found closes #88

### DIFF
--- a/docs/tables/github_tag.md
+++ b/docs/tables/github_tag.md
@@ -29,7 +29,7 @@ from
 where
   repository_full_name = 'turbot/steampipe'
 order by
-  string_to_array(regexp_replace(name, '[^0-9\.]', '', 'g'), '.')::int[],
+  string_to_array(regexp_replace(name, '[^0-9\.]', '', 'g'), '.'),
   name;
 ```
 

--- a/github/table_github_repository.go
+++ b/github/table_github_repository.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/go-github/v33/github"
 
@@ -156,6 +157,9 @@ func tableGitHubRepositoryGet(ctx context.Context, d *plugin.QueryData, h *plugi
 	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
 
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil, nil
+		}
 		return nil, err
 	}
 	getResp := getResponse.(GetResponse)
@@ -208,6 +212,9 @@ func tableGitHubRepositoryCollaboratorsGetVariation(variant string, ctx context.
 		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
 
 		if err != nil {
+			if strings.Contains(err.Error(), "404") {
+				return nil, nil
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  r.name,
  collaborator_login
from
  github_my_repository as r,
  jsonb_array_elements_text(r.collaborator_logins) as collaborator_login,
  github_my_organization as o
where
  r.owner_login = o.login
  and collaborator_login not in (
    select m from github_my_organization, jsonb_array_elements_text(member_logins) as m
  );
+------+--------------------+
| name | collaborator_login |
+------+--------------------+
+------+--------------------+
```
</details>
