### PR TITLE
Add repository_full_name column in github_search_* tables closes #129

### DIFF
--- a/docs/tables/github_search_code.md
+++ b/docs/tables/github_search_code.md
@@ -13,6 +13,7 @@ select
   name,
   query,
   html_url,
+  repository_full_name,
   sha
 from
   github_search_code

--- a/docs/tables/github_search_commits.md
+++ b/docs/tables/github_search_commits.md
@@ -13,6 +13,7 @@ select
   sha,
   query,
   html_url,
+  repository_full_name,
   score
 from
   github_search_commit

--- a/docs/tables/github_search_label.md
+++ b/docs/tables/github_search_label.md
@@ -13,6 +13,7 @@ select
   id,
   repository_id,
   name,
+  repository_full_name,
   description
 from
   github_search_label

--- a/docs/tables/github_search_pull_request.md
+++ b/docs/tables/github_search_pull_request.md
@@ -14,6 +14,7 @@ select
   id,
   state,
   created_at,
+  repository_full_name,
   html_url
 from
   github_search_pull_request

--- a/github/table_github_search_pull_request.go
+++ b/github/table_github_search_pull_request.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/go-github/v33/github"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -38,6 +39,7 @@ func tableGitHubSearchPullRequest(ctx context.Context) *plugin.Table {
 			{Name: "node_id", Type: proto.ColumnType_STRING, Description: "The node ID of the pull request."},
 			{Name: "number", Type: proto.ColumnType_INT, Description: "The number of the pull request."},
 			{Name: "repository_url", Type: proto.ColumnType_STRING, Description: "The API URL of the repository for the pull request."},
+			{Name: "repository_full_name", Type: proto.ColumnType_STRING, Transform: transform.From(extractSearchPullReqRepositoryFullName), Description: "The full name of the repository (login/repo-name)."},
 			{Name: "updated_at", Type: proto.ColumnType_TIMESTAMP, Description: "The timestamp the pull request updated at."},
 			{Name: "url", Type: proto.ColumnType_STRING, Transform: transform.FromField("URL"), Description: "The API URL of the pull request."},
 			{Name: "assignee", Type: proto.ColumnType_JSON, Description: "The assignee details."},
@@ -132,4 +134,14 @@ func tableGitHubSearchPullRequestList(ctx context.Context, d *plugin.QueryData, 
 	}
 
 	return nil, nil
+}
+
+//// TRANSFORM FUNCTION
+
+func extractSearchPullReqRepositoryFullName(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	pr := d.HydrateItem.(*github.Issue)
+	if pr.RepositoryURL != nil {
+		return strings.Replace(*pr.RepositoryURL, "https://api.github.com/repos/", "", -1), nil
+	}
+	return "", nil
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, repository_full_name from github_search_code where query = 'filename:table_github_my_organization RowsRemaining';
+---------------------------------+--------------------------------+
| name                            | repository_full_name           |
+---------------------------------+--------------------------------+
| table_github_my_organization.go | turbot/steampipe-plugin-github |
+---------------------------------+--------------------------------+

 select sha, repository_full_name, url from github_search_commit where query = 'Add table github_my_star org:turbot';
+------------------------------------------+--------------------------------+--------------------------------------------------------------------------------------------------------------+
| sha                                      | repository_full_name           | url                                                                                                          |
+------------------------------------------+--------------------------------+--------------------------------------------------------------------------------------------------------------+
| 15c07531167143bf7e5c3629307f50047ec416f5 | turbot/steampipe-plugin-github | https://api.github.com/repos/turbot/steampipe-plugin-github/commits/15c07531167143bf7e5c3629307f50047ec416f5 |
+------------------------------------------+--------------------------------+--------------------------------------------------------------------------------------------------------------+

> select name, repository_full_name, url from github_search_label where repository_id = 331646306 and query = 'bug enhancement blocked'
+-------------+--------------------------------+--------------------------------------------------------------------------------+
| name        | repository_full_name           | url                                                                            |
+-------------+--------------------------------+--------------------------------------------------------------------------------+
| bug         | turbot/steampipe-plugin-github | https://api.github.com/repos/turbot/steampipe-plugin-github/labels/bug         |
| enhancement | turbot/steampipe-plugin-github | https://api.github.com/repos/turbot/steampipe-plugin-github/labels/enhancement |
| blocked     | turbot/steampipe-plugin-github | https://api.github.com/repos/turbot/steampipe-plugin-github/labels/blocked     |
+-------------+--------------------------------+--------------------------------------------------------------------------------+

> select title, repository_full_name, repository_url from github_search_pull_request where query = 'github_search_issue in:title in:body in:comments';
+-------------------------------------------------------------------------------+--------------------------------+-------------------------------------------------------------+
| title                                                                         | repository_full_name           | repository_url                                              |
+-------------------------------------------------------------------------------+--------------------------------+-------------------------------------------------------------+
| Add table github_search_pull_request. Closes #110                             | turbot/steampipe-plugin-github | https://api.github.com/repos/turbot/steampipe-plugin-github |
| Add table github_search_issue. Closes #102                                    | turbot/steampipe-plugin-github | https://api.github.com/repos/turbot/steampipe-plugin-github |
| Add repository_full_name column to the github_search_issue table closes #122  | turbot/steampipe-plugin-github | https://api.github.com/repos/turbot/steampipe-plugin-github |
| repository column in the github_search_issue table is always null closes #124 | turbot/steampipe-plugin-github | https://api.github.com/repos/turbot/steampipe-plugin-github |
+-------------------------------------------------------------------------------+--------------------------------+-------------------------------------------------------------+

```
</details>


