### PR TITLE
Support GitHub audit logs

### DIFF
--- a/docs/tables/github_audit_log.md
+++ b/docs/tables/github_audit_log.md
@@ -1,6 +1,6 @@
 # Table: github_audit_log
 
-The `github_audit_log` table helps to find all audit events for an organization.
+The `github_audit_log` table helps to find all audit events for an organization. Note: this only works for organizations on an **GitHub Enterprise plan**.
 
 **You must always specify the organization** in the where or join clause using the `organization` column. Additionally, you can filter the logs by using a search phrase (`phrase`), event types (`include`), and before/after a timestamp (`created_at`).
 
@@ -19,6 +19,7 @@ from
   github_audit_log
 where
   organization = 'my_org'
+order by created_at
 limit 10;
 ```
 

--- a/docs/tables/github_audit_log.md
+++ b/docs/tables/github_audit_log.md
@@ -6,22 +6,7 @@ The `github_audit_log` table helps to find all audit events for an organization.
 
 ## Examples
 
-### Get all audit events for an organization
-
-```sql
-select
-  id,
-  created_at,
-  actor,
-  action,
-  data
-from
-  github_audit_log
-where
-  organization = 'my_org';
-```
-
-### Get specific audit events
+### Get recent audit events for an organization
 
 ```sql
 select
@@ -34,6 +19,42 @@ from
   github_audit_log
 where
   organization = 'my_org'
-  and phrase = "action:repo.create action:repo.destroy"
-  and created_at >= '2022-01-01';
+limit 10;
+```
+
+### Get specific audit events
+
+For example, find out which repos have been created or deleted on the first of January.
+
+```sql
+select
+  id,
+  created_at,
+  actor,
+  action,
+  data
+from
+  github_audit_log
+where
+  organization = 'my_org'
+  and action IN ('repo.create', 'repo.destroy')
+  and created_at = '2022-01-01';
+```
+
+### Get specific events by a specific actor (user) in the last 30 days
+
+```sql
+select
+  id,
+  created_at,
+  actor,
+  action,
+  data
+from
+  github_audit_log
+where
+  organization = 'my_org'
+  and actor = 'some_user'
+  and created_at > (created_at - interval '30' day)
+order by created_at;
 ```

--- a/docs/tables/github_audit_log.md
+++ b/docs/tables/github_audit_log.md
@@ -16,9 +16,9 @@ select
   action,
   data
 from
-    github_audit_log
+  github_audit_log
 where
-    organization = 'my_org'
+  organization = 'my_org';
 ```
 
 ### Get specific audit events
@@ -31,9 +31,9 @@ select
   action,
   data
 from
-    github_audit_log
+  github_audit_log
 where
-    organization = 'my_org'
-    and phrase = "action:repo.create action:repo.destroy"
-    and created_at >= '2022-01-01'
+  organization = 'my_org'
+  and phrase = "action:repo.create action:repo.destroy"
+  and created_at >= '2022-01-01';
 ```

--- a/docs/tables/github_audit_log.md
+++ b/docs/tables/github_audit_log.md
@@ -16,7 +16,7 @@ select
   action,
   data
 from
-    github.github_audit_log
+    github_audit_log
 where
     organization = 'my_org'
 ```
@@ -31,7 +31,7 @@ select
   action,
   data
 from
-    github.github_audit_log
+    github_audit_log
 where
     organization = 'my_org'
     and phrase = "action:repo.create action:repo.destroy"

--- a/docs/tables/github_audit_log.md
+++ b/docs/tables/github_audit_log.md
@@ -1,0 +1,39 @@
+# Table: github_audit_log
+
+The `github_audit_log` table helps to find all audit events for an organization.
+
+**You must always specify the organization** in the where or join clause using the `organization` column. Additionally, you can filter the logs by using a search phrase (`phrase`), event types (`include`), and before/after a timestamp (`created_at`).
+
+## Examples
+
+### Get all audit events for an organization
+
+```sql
+select
+  id,
+  created_at,
+  actor,
+  action,
+  data
+from
+    github.github_audit_log
+where
+    organization = 'my_org'
+```
+
+### Get specific audit events
+
+```sql
+select
+  id,
+  created_at,
+  actor,
+  action,
+  data
+from
+    github.github_audit_log
+where
+    organization = 'my_org'
+    and phrase = "action:repo.create action:repo.destroy"
+    and created_at >= '2022-01-01'
+```

--- a/github/plugin.go
+++ b/github/plugin.go
@@ -21,6 +21,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"github_actions_repository_runner":       tableGitHubActionsRepositoryRunner(ctx),
 			"github_actions_repository_secret":       tableGitHubActionsRepositorySecret(ctx),
 			"github_actions_repository_workflow_run": tableGitHubActionsRepositoryWorkflowRun(ctx),
+			"github_audit_log":                       tableGitHubAuditLog(ctx),
 			"github_branch_protection":               tableGitHubBranchProtection(ctx),
 			"github_branch":                          tableGitHubBranch(ctx),
 			"github_commit":                          tableGitHubCommit(ctx),

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -60,6 +60,8 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 		ListCursorOptions: github.ListCursorOptions{PerPage: 100},
 	}
 
+	// TODO: Support quals["action"] to filter using the phrase parameter
+
 	if quals["created_at"] != nil {
 		for _, q := range d.Quals["created_at"].Quals {
 			givenTime := q.Value.GetTimestampValue().AsTime().Format(time.RFC3339)
@@ -69,6 +71,8 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 				op = ""
 			}
 
+			// TODO: Handle BETWEEN clause
+			// TODO: Handle from/to to use created:<fromt>...<to> instead
 			phrase += " created:" + op + givenTime
 			opts.Phrase = &phrase
 		}

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -21,6 +21,7 @@ func tableGitHubAuditLog(ctx context.Context) *plugin.Table {
 				{Name: "organization", Require: plugin.Required},
 				{Name: "phrase", Require: plugin.Optional},
 				{Name: "include", Require: plugin.Optional},
+				{Name: "action", Require: plugin.Optional},
 				{Name: "created_at", Require: plugin.Optional, Operators: []string{">", ">=", "<", "<=", "="}},
 			},
 			Hydrate: tableGitHubAuditLogList,
@@ -60,8 +61,6 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 		ListCursorOptions: github.ListCursorOptions{PerPage: 100},
 	}
 
-	// TODO: Support quals["action"] to filter using the phrase parameter
-
 	if d.Quals["created_at"] != nil {
 		for _, q := range d.Quals["created_at"].Quals {
 			givenTime := q.Value.GetTimestampValue().AsTime().Format(time.RFC3339)
@@ -74,6 +73,11 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 			phrase += " created:" + op + givenTime
 			opts.Phrase = &phrase
 		}
+	}
+
+	if quals["action"] != nil {
+		phrase += " action:" + quals["action"].GetStringValue()
+		opts.Phrase = &phrase
 	}
 
 	type ListPageResponse struct {

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -84,8 +84,8 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 	}
 
 	type ListPageResponse struct {
-		result []*github.AuditEntry
-		resp   *github.Response
+		entries []*github.AuditEntry
+		resp    *github.Response
 	}
 
 	client := connect(ctx, d)
@@ -99,15 +99,15 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 	}
 
 	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		result, resp, err := client.Organizations.GetAuditLog(ctx, org, opts)
+		entries, resp, err := client.Organizations.GetAuditLog(ctx, org, opts)
 
 		if err != nil {
 			return nil, err
 		}
 
 		return ListPageResponse{
-			result: result,
-			resp:   resp,
+			entries: entries,
+			resp:    resp,
 		}, nil
 	}
 
@@ -119,7 +119,7 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 		}
 
 		listResponse := listPageResponse.(ListPageResponse)
-		auditResults := listResponse.result
+		auditResults := listResponse.entries
 		resp := listResponse.resp
 
 		for _, i := range auditResults {
@@ -131,11 +131,11 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 			}
 		}
 
-		if resp.NextPage == 0 {
+		if resp.After == "" {
 			break
 		}
 
-		opts.ListCursorOptions.Page = resp.NextPageToken
+		opts.After = resp.After
 	}
 
 	return nil, nil

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -31,11 +31,11 @@ func tableGitHubAuditLog(ctx context.Context) *plugin.Table {
 			{Name: "include", Type: pb.ColumnType_STRING, Transform: transform.FromQual("include"), Description: "The event types to include: web, git, all."},
 
 			// Top columns.
-			{Name: "id", Type: pb.ColumnType_STRING, Description: "The id of the audit event.", Transform: transform.FromField("_document_id")},
-			{Name: "created_at", Type: pb.ColumnType_TIMESTAMP, Description: "The timestamp of the audit event.", Transform: transform.FromField("created_at").Transform(convertTimestamp)},
+			{Name: "id", Type: pb.ColumnType_STRING, Description: "The id of the audit event.", Transform: transform.FromField("DocumentID")},
+			{Name: "created_at", Type: pb.ColumnType_TIMESTAMP, Description: "The timestamp of the audit event.", Transform: transform.FromField("CreatedAt").Transform(convertTimestamp)},
 			{Name: "action", Type: pb.ColumnType_STRING, Description: "The action performed."},
 			{Name: "actor", Type: pb.ColumnType_STRING, Description: "The GitHub user who performed the action."},
-			{Name: "actor_location_country_code", Type: pb.ColumnType_STRING, Description: "The country location of the actor at the moment of the action.", Transform: transform.FromField("actor_location.country_code")},
+			{Name: "actor_location_country_code", Type: pb.ColumnType_STRING, Description: "The country location of the actor at the moment of the action.", Transform: transform.FromField("ActorLocation.CountryCode")},
 
 			// Optional columns, depending on the audit event.
 			{Name: "team", Type: pb.ColumnType_STRING, Description: "The GitHub team, when the action relates to a team."},

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -62,7 +62,7 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 
 	// TODO: Support quals["action"] to filter using the phrase parameter
 
-	if quals["created_at"] != nil {
+	if d.Quals["created_at"] != nil {
 		for _, q := range d.Quals["created_at"].Quals {
 			givenTime := q.Value.GetTimestampValue().AsTime().Format(time.RFC3339)
 
@@ -71,8 +71,6 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 				op = ""
 			}
 
-			// TODO: Handle BETWEEN clause
-			// TODO: Handle from/to to use created:<fromt>...<to> instead
 			phrase += " created:" + op + givenTime
 			opts.Phrase = &phrase
 		}
@@ -94,6 +92,7 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 	}
 
 	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		plugin.Logger(ctx).Debug("tableGitHubAuditLogs", "org", org, "include", include, "phrase", *opts.Phrase)
 		entries, resp, err := client.Organizations.GetAuditLog(ctx, org, opts)
 
 		if err != nil {

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v45/github"
-	pb "github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin/transform"
 )
@@ -15,7 +15,7 @@ import (
 func tableGitHubAuditLog(ctx context.Context) *plugin.Table {
 	return &plugin.Table{
 		Name:        "github_audit_log",
-		Description: "Gets the audit log for an organization.",
+		Description: "Gets the audit logs for an organization.",
 		List: &plugin.ListConfig{
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "organization", Require: plugin.Required},
@@ -28,22 +28,22 @@ func tableGitHubAuditLog(ctx context.Context) *plugin.Table {
 			Hydrate: tableGitHubAuditLogList,
 		},
 		Columns: []*plugin.Column{
-			{Name: "organization", Type: pb.ColumnType_STRING, Transform: transform.FromQual("organization")},
-			{Name: "phrase", Type: pb.ColumnType_STRING, Transform: transform.FromQual("phrase"), Description: "The search phrase for your audit events."},
-			{Name: "include", Type: pb.ColumnType_STRING, Transform: transform.FromQual("include"), Description: "The event types to include: web, git, all."},
+			{Name: "organization", Type: proto.ColumnType_STRING, Transform: transform.FromQual("organization"), Description: "The GitHub organization."},
+			{Name: "phrase", Type: proto.ColumnType_STRING, Transform: transform.FromQual("phrase"), Description: "The search phrase for your audit events."},
+			{Name: "include", Type: proto.ColumnType_STRING, Transform: transform.FromQual("include"), Description: "The event types to include: web, git, all."},
 
 			// Top columns.
-			{Name: "id", Type: pb.ColumnType_STRING, Description: "The id of the audit event.", Transform: transform.FromField("DocumentID")},
-			{Name: "created_at", Type: pb.ColumnType_TIMESTAMP, Description: "The timestamp of the audit event.", Transform: transform.FromField("CreatedAt").Transform(convertTimestamp)},
-			{Name: "action", Type: pb.ColumnType_STRING, Description: "The action performed."},
-			{Name: "actor", Type: pb.ColumnType_STRING, Description: "The GitHub user who performed the action."},
-			{Name: "actor_location_country_code", Type: pb.ColumnType_STRING, Description: "The country location of the actor at the moment of the action.", Transform: transform.FromField("ActorLocation.CountryCode")},
+			{Name: "id", Type: proto.ColumnType_STRING, Description: "The id of the audit event.", Transform: transform.FromField("DocumentID")},
+			{Name: "created_at", Type: proto.ColumnType_TIMESTAMP, Description: "The timestamp of the audit event.", Transform: transform.FromField("CreatedAt").Transform(convertTimestamp)},
+			{Name: "action", Type: proto.ColumnType_STRING, Description: "The action performed."},
+			{Name: "actor", Type: proto.ColumnType_STRING, Description: "The GitHub user who performed the action."},
+			{Name: "actor_location", Type: proto.ColumnType_JSON, Description: "The actor's location at the moment of the action."},
 
 			// Optional columns, depending on the audit event.
-			{Name: "team", Type: pb.ColumnType_STRING, Description: "The GitHub team, when the action relates to a team."},
-			{Name: "user", Type: pb.ColumnType_STRING, Description: "The GitHub user, when the action relates to a user."},
-			{Name: "repo", Type: pb.ColumnType_STRING, Description: "The GitHub repository, when the action relates to a repository."},
-			{Name: "data", Type: pb.ColumnType_JSON, Description: "Additional data relating to the audit event."},
+			{Name: "team", Type: proto.ColumnType_STRING, Description: "The GitHub team, when the action relates to a team."},
+			{Name: "user", Type: proto.ColumnType_STRING, Description: "The GitHub user, when the action relates to a user."},
+			{Name: "repo", Type: proto.ColumnType_STRING, Description: "The GitHub repository, when the action relates to a repository."},
+			{Name: "data", Type: proto.ColumnType_JSON, Description: "Additional data relating to the audit event."},
 		},
 	}
 }

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -32,7 +32,7 @@ func tableGitHubAuditLog(ctx context.Context) *plugin.Table {
 
 			// Top columns.
 			{Name: "id", Type: pb.ColumnType_STRING, Description: "The id of the audit event.", Transform: transform.FromField("_document_id")},
-			{Name: "created_at", Type: pb.ColumnType_TIMESTAMP, Description: "The timestamp of the audit event."},
+			{Name: "created_at", Type: pb.ColumnType_TIMESTAMP, Description: "The timestamp of the audit event.", Transform: transform.FromField("created_at").Transform(convertTimestamp)},
 			{Name: "action", Type: pb.ColumnType_STRING, Description: "The action performed."},
 			{Name: "actor", Type: pb.ColumnType_STRING, Description: "The GitHub user who performed the action."},
 			{Name: "actor_location_country_code", Type: pb.ColumnType_STRING, Description: "The country location of the actor at the moment of the action.", Transform: transform.FromField("actor_location.country_code")},

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -22,6 +22,7 @@ func tableGitHubAuditLog(ctx context.Context) *plugin.Table {
 				{Name: "phrase", Require: plugin.Optional},
 				{Name: "include", Require: plugin.Optional},
 				{Name: "action", Require: plugin.Optional},
+				{Name: "actor", Require: plugin.Optional},
 				{Name: "created_at", Require: plugin.Optional, Operators: []string{">", ">=", "<", "<=", "="}},
 			},
 			Hydrate: tableGitHubAuditLogList,
@@ -77,6 +78,11 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 
 	if quals["action"] != nil {
 		phrase += " action:" + quals["action"].GetStringValue()
+		opts.Phrase = &phrase
+	}
+
+	if quals["actor"] != nil {
+		phrase += " actor:" + quals["actor"].GetStringValue()
 		opts.Phrase = &phrase
 	}
 

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -1,0 +1,142 @@
+package github
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/go-github/v45/github"
+	pb "github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v3/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableGitHubAuditLog(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "github_audit_log",
+		Description: "Gets the audit log for an organization.",
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "organization", Require: plugin.Required},
+				{Name: "phrase", Require: plugin.Optional},
+				{Name: "include", Require: plugin.Optional},
+				{Name: "created_at", Require: plugin.Optional, Operators: []string{">", ">=", "<", "<=", "="}},
+			},
+			Hydrate: tableGitHubAuditLogList,
+		},
+		Columns: []*plugin.Column{
+			{Name: "organization", Type: pb.ColumnType_STRING, Transform: transform.FromQual("organization")},
+			{Name: "phrase", Type: pb.ColumnType_STRING, Transform: transform.FromQual("phrase"), Description: "The search phrase for your audit events."},
+			{Name: "include", Type: pb.ColumnType_STRING, Transform: transform.FromQual("include"), Description: "The event types to include: web, git, all."},
+
+			// Top columns.
+			{Name: "id", Type: pb.ColumnType_STRING, Description: "The id of the audit event.", Transform: transform.FromField("_document_id")},
+			{Name: "created_at", Type: pb.ColumnType_TIMESTAMP, Description: "The timestamp of the audit event."},
+			{Name: "action", Type: pb.ColumnType_STRING, Description: "The action performed."},
+			{Name: "actor", Type: pb.ColumnType_STRING, Description: "The GitHub user who performed the action."},
+			{Name: "actor_location_country_code", Type: pb.ColumnType_STRING, Description: "The country location of the actor at the moment of the action.", Transform: transform.FromField("actor_location.country_code")},
+
+			// Optional columns, depending on the audit event.
+			{Name: "team", Type: pb.ColumnType_STRING, Description: "The GitHub team, when the action relates to a team."},
+			{Name: "user", Type: pb.ColumnType_STRING, Description: "The GitHub user, when the action relates to a user."},
+			{Name: "repo", Type: pb.ColumnType_STRING, Description: "The GitHub repository, when the action relates to a repository."},
+			{Name: "data", Type: pb.ColumnType_JSON, Description: "Additional data relating to the audit event."},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	quals := d.KeyColumnQuals
+	org := quals["organization"].GetStringValue()
+	phrase := quals["phrase"].GetStringValue()
+	include := quals["include"].GetStringValue()
+
+	opts := &github.GetAuditLogOptions{
+		Phrase:            &phrase,
+		Include:           &include,
+		ListCursorOptions: github.ListCursorOptions{PerPage: 100},
+	}
+
+	if quals["created_at"] != nil {
+		for _, q := range d.Quals["created_at"].Quals {
+			input := q.Value.GetTimestampValue().AsTime()
+			givenTime := input.Format("2006-01-02")
+			beforeTime := input.Add(-24 * time.Hour).Format("2006-01-02")
+			afterTime := input.Add(24 * time.Hour).Format("2006-01-02")
+
+			switch q.Operator {
+			case ">":
+				opts.After = afterTime
+			case ">=":
+				opts.After = givenTime
+			case "<":
+				opts.Before = beforeTime
+			case "<=":
+				opts.Before = givenTime
+			case "=":
+				phrase += " created: " + givenTime
+				opts.Phrase = &phrase
+			}
+		}
+	}
+
+	type ListPageResponse struct {
+		result []*github.AuditEntry
+		resp   *github.Response
+	}
+
+	client := connect(ctx, d)
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if limit != nil {
+		if *limit < int64(opts.ListCursorOptions.PerPage) {
+			opts.ListCursorOptions.PerPage = int(*limit)
+		}
+	}
+
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		result, resp, err := client.Organizations.GetAuditLog(ctx, org, opts)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return ListPageResponse{
+			result: result,
+			resp:   resp,
+		}, nil
+	}
+
+	for {
+		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+
+		if err != nil {
+			return nil, err
+		}
+
+		listResponse := listPageResponse.(ListPageResponse)
+		auditResults := listResponse.result
+		resp := listResponse.resp
+
+		for _, i := range auditResults {
+			d.StreamListItem(ctx, i)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+
+		opts.ListCursorOptions.Page = resp.NextPageToken
+	}
+
+	return nil, nil
+}

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -62,24 +62,15 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 
 	if quals["created_at"] != nil {
 		for _, q := range d.Quals["created_at"].Quals {
-			input := q.Value.GetTimestampValue().AsTime()
-			givenTime := input.Format("2006-01-02")
-			beforeTime := input.Add(-24 * time.Hour).Format("2006-01-02")
-			afterTime := input.Add(24 * time.Hour).Format("2006-01-02")
+			givenTime := q.Value.GetTimestampValue().AsTime().Format(time.RFC3339)
 
-			switch q.Operator {
-			case ">":
-				opts.After = afterTime
-			case ">=":
-				opts.After = givenTime
-			case "<":
-				opts.Before = beforeTime
-			case "<=":
-				opts.Before = givenTime
-			case "=":
-				phrase += " created: " + givenTime
-				opts.Phrase = &phrase
+			op := q.Operator
+			if op == "=" {
+				op = ""
 			}
+
+			phrase += " created:" + op + givenTime
+			opts.Phrase = &phrase
 		}
 	}
 


### PR DESCRIPTION
Fixes #164 

Unfortunately not able to test myself, as this requires Enterprise access. However, based on the export from the UI I've verified the fields.

To fetch audit logs using the API, required an upgrade to the `go-github` package. I can also do that in a separate PR, if that's preferred.