### PR TITLE
Refactor all Get hydrates

### DIFF
--- a/github/table_github_actions_repository_runner.go
+++ b/github/table_github_actions_repository_runner.go
@@ -103,38 +103,22 @@ func tableGitHubRunnerList(ctx context.Context, d *plugin.QueryData, h *plugin.H
 //// HYDRATE FUNCTIONS
 
 func tableGitHubRunnerGet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	runnerId := d.KeyColumnQuals["id"].GetInt64Value()
-	orgName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
+	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, client *github.Client) (interface{}, error) {
+		runnerId := d.KeyColumnQuals["id"].GetInt64Value()
+		fullname := d.KeyColumnQuals["repository_full_name"].GetStringValue()
 
-	// Empty check for the parameter
-	if runnerId == 0 || orgName == "" {
-		return nil, nil
+		// Empty check for the parameter
+		if runnerId == 0 || fullname == "" {
+			return nil, nil
+		}
+
+		owner, repo := parseRepoFullName(fullname)
+
+		plugin.Logger(ctx).Trace("tableGitHubRunnerGet", "owner", owner, "repo", repo, "runnerId", runnerId)
+		detail, _, err := client.Actions.GetRunner(ctx, owner, repo, runnerId)
+
+		return detail, err
 	}
 
-	owner, repo := parseRepoFullName(orgName)
-	plugin.Logger(ctx).Trace("tableGitHubRunnerGet", "owner", owner, "repo", repo, "runnerId", runnerId)
-
-	client := connect(ctx, d)
-
-	type GetResponse struct {
-		runner *github.Runner
-		resp   *github.Response
-	}
-
-	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		detail, resp, err := client.Actions.GetRunner(ctx, owner, repo, runnerId)
-		return GetResponse{
-			runner: detail,
-			resp:   resp,
-		}, err
-	}
-
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
-	if err != nil {
-		return nil, err
-	}
-
-	getResp := getResponse.(GetResponse)
-
-	return getResp.runner, nil
+	return getGitHubItem(ctx, d, h, getDetails)
 }

--- a/github/table_github_branch_protection.go
+++ b/github/table_github_branch_protection.go
@@ -45,31 +45,22 @@ func tableGitHubBranchProtection(ctx context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func tableGitHubRepositoryBranchProtectionGet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	logger := plugin.Logger(ctx)
-	quals := d.KeyColumnQuals
+	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, client *github.Client) (interface{}, error) {
+		fullName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
+		owner, repo := parseRepoFullName(fullName)
 
-	fullName := quals["repository_full_name"].GetStringValue()
-	owner, repo := parseRepoFullName(fullName)
+		branchName := ""
 
-	branchName := ""
+		if h.Item != nil {
+			b := h.Item.(*github.Branch)
+			branchName = *b.Name
+		} else {
+			branchName = d.KeyColumnQuals["name"].GetStringValue()
+		}
 
-	if h.Item != nil {
-		b := h.Item.(*github.Branch)
-		branchName = *b.Name
-	} else {
-		branchName = quals["name"].GetStringValue()
-	}
+		plugin.Logger(ctx).Trace("tableGitHubRepositoryBranchProtectionGet", "owner", owner, "repo", repo, "branchName", branchName)
+		detail, _, err := client.Repositories.GetBranchProtection(ctx, owner, repo, branchName)
 
-	logger.Trace("tableGitHubRepositoryBranchProtectionGet", "owner", owner, "repo", repo, "branchName", branchName)
-
-	client := connect(ctx, d)
-
-	type GetResponse struct {
-		protection *github.Protection
-	}
-
-	get := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		protection, _, err := client.Repositories.GetBranchProtection(ctx, owner, repo, branchName)
 		if err != nil {
 			// For private and archived repositories, users who do not have owner/admin access will get the below error
 			// 403 Upgrade to GitHub Pro or make this repository public to enable this feature.
@@ -77,28 +68,19 @@ func tableGitHubRepositoryBranchProtectionGet(ctx context.Context, d *plugin.Que
 			if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Upgrade to GitHub Pro") {
 				return nil, nil
 			}
+
 			return nil, err
 		}
 
-		return GetResponse{
-			protection: protection,
-		}, err
+		return detail, err
 	}
 
-	getDetails, err := plugin.RetryHydrate(ctx, d, h, get, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
-	if err != nil {
-		return nil, err
-	}
-
-	if getDetails == nil {
-		return nil, nil
-	}
-	getResp := getDetails.(GetResponse)
-	protection := getResp.protection
+	protection, _ := getGitHubItem(ctx, d, h, getDetails)
 
 	if protection != nil {
 		d.StreamLeafListItem(ctx, protection)
 	}
+
 	return nil, nil
 }
 

--- a/github/table_github_gitignore.go
+++ b/github/table_github_gitignore.go
@@ -34,81 +34,40 @@ func tableGitHubGitignore() *plugin.Table {
 //// LIST FUNCTION
 
 func tableGitHubGitignoreList(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	client := connect(ctx, d)
+	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, client *github.Client) (interface{}, error) {
+		raw, _, err := client.Gitignores.List(ctx)
 
-	type ListPageResponse struct {
-		gitIgnores []string
-		resp       *github.Response
-	}
-
-	listPage := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		gitignore, resp, err := client.Gitignores.List(ctx)
-		return ListPageResponse{
-			gitIgnores: gitignore,
-			resp:       resp,
-		}, err
-	}
-
-	listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
-
-	if err != nil {
-		return nil, err
-	}
-
-	listResponse := listPageResponse.(ListPageResponse)
-	gitIgnores := listResponse.gitIgnores
-
-	for _, i := range gitIgnores {
-		if i != "" {
-			d.StreamListItem(ctx, github.Gitignore{Name: github.String(i)})
+		var list []github.Gitignore
+		for _, v := range raw {
+			list = append(list, github.Gitignore{Name: github.String(v)})
 		}
 
-		// Context can be cancelled due to manual cancellation or the limit has been hit
-		if d.QueryStatus.RowsRemaining(ctx) == 0 {
-			return nil, nil
-		}
+		return list, err
 	}
-	return nil, nil
+
+	return streamGitHubListOrItem(ctx, d, h, listPage)
 }
 
 //// HYDRATE FUNCTIONS
 
 func tableGitHubGitignoreGetData(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	var name string
-	if h.Item != nil {
-		item := h.Item.(github.Gitignore)
-		name = *item.Name
-	} else {
-		name = d.KeyColumnQuals["name"].GetStringValue()
+	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, client *github.Client) (interface{}, error) {
+		var name string
+		if h.Item != nil {
+			item := h.Item.(github.Gitignore)
+			name = *item.Name
+		} else {
+			name = d.KeyColumnQuals["name"].GetStringValue()
+		}
+
+		// Return nil, if no input provided
+		if name == "" {
+			return nil, nil
+		}
+		detail, _, err := client.Gitignores.Get(ctx, name)
+
+		return detail, err
 	}
 
-	// Return nil, if no input provided
-	if name == "" {
-		return nil, nil
-	}
-
-	client := connect(ctx, d)
-
-	type GetResponse struct {
-		gitIgnore *github.Gitignore
-		resp      *github.Response
-	}
-
-	getDetails := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		detail, resp, err := client.Gitignores.Get(ctx, name)
-		return GetResponse{
-			gitIgnore: detail,
-			resp:      resp,
-		}, err
-	}
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
-
-	if err != nil {
-		return nil, err
-	}
-
-	getResp := getResponse.(GetResponse)
-	gitIgnore := getResp.gitIgnore
-
-	return gitIgnore, nil
+	return getGitHubItem(ctx, d, h, getDetails)
 }


### PR DESCRIPTION
There's a lot of duplication when hydrating the data. Likely from copy-pasting over time.

The aim of this PR is to decrease that for "get" hydrates.

Refactoring the list hydrates are a bit trickier, so I started out with just the gets. Lists can be done in a separate PR.

- [x] Refactor get hydrates into a single function
- [x] Always log upon hydrating