### PR TITLE
add links to specific github search docs

### DIFF
--- a/docs/tables/github_search_code.md
+++ b/docs/tables/github_search_code.md
@@ -1,8 +1,8 @@
 # Table: github_search_code
 
-The `github_search_code` table helps to search for the specific item you want to find inside of a file. You can search globally across all of GitHub, or scope your search to a particular repository or organization.
+The `github_search_code` table helps to search for the specific item you want to find inside of a file. You can search globally across all of GitHub, or scope your search to a particular repository or organization. 
 
- **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. The `query` contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub.
+ **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. The `query` contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. See [Searching code](https://docs.github.com/search-github/searching-on-github/searching-code) for details on the GitHub query syntax.
 
 ## Examples
 

--- a/docs/tables/github_search_code.md
+++ b/docs/tables/github_search_code.md
@@ -1,6 +1,6 @@
 # Table: github_search_code
 
-The `github_search_code` table helps to search for the specific item you want to find inside of a file. You can search globally across all of GitHub, or scope your search to a particular repository or organization. 
+The `github_search_code` table helps to search for the specific item you want to find inside of a file. You can search globally across all of GitHub, or scope your search to a particular repository or organization.
 
  **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. The `query` contains one or more search keywords and qualifiers. Qualifiers allow you to limit your search to specific areas of GitHub. See [Searching code](https://docs.github.com/search-github/searching-on-github/searching-code) for details on the GitHub query syntax.
 

--- a/docs/tables/github_search_commit.md
+++ b/docs/tables/github_search_commit.md
@@ -2,7 +2,7 @@
 
 The `github_search_commit` table helps to find commits via various criteria on the default branch (usually master). You can search for commits globally across all of GitHub, or search for commits within a particular repository or organization.
 
- **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. You can narrow the results using these commit search qualifiers in any combination.
+ **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. You can narrow the results using these commit search qualifiers in any combination. See [Searching commits](https://docs.github.com/search-github/searching-on-github/searching-commits) for details on the GitHub query syntax.
 
 ## Examples
 

--- a/docs/tables/github_search_issue.md
+++ b/docs/tables/github_search_issue.md
@@ -2,7 +2,7 @@
 
 The `github_search_issue` table helps to find issues by state and keyword. You can search for issues globally across all of GitHub, or search for issues within a particular organization.
 
- **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. You can narrow the results using these search qualifiers in any combination. See [Searching issues and pull requests](https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests) for details.
+ **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. You can narrow the results using these search qualifiers in any combination. See [Searching issues and pull requests](https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests) for details on the GitHub query syntax.
 
 ## Examples
 

--- a/docs/tables/github_search_pull_request.md
+++ b/docs/tables/github_search_pull_request.md
@@ -2,7 +2,7 @@
 
 The `github_search_pull_request` table helps to find pull requests by state and keyword. You can search for pull requests globally across all of GitHub, or search for pull requests within a particular organization.
 
- **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. You can narrow the results using these search qualifiers in any combination.
+ **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. You can narrow the results using these search qualifiers in any combination. See [Searching issues and pull requests](https://docs.github.com/search-github/searching-on-github/searching-issues-and-pull-requests) for details on the GitHub query syntax.
 
 ## Examples
 

--- a/docs/tables/github_search_repository.md
+++ b/docs/tables/github_search_repository.md
@@ -2,7 +2,8 @@
 
 The `github_search_repository` table helps to find repositories via various criteria. You can search for repositories on GitHub and narrow the results using these repository search qualifiers in any combination.
 
- **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. You can search for repositories globally across all of GitHub.com, or search for repositories within a particular organization.
+ **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. You can search for repositories globally across all of GitHub.com, or search for repositories within a particular organization. See [Searching for repositories](https://docs.github.com/search-github/searching-on-github/searching-for-repositories) for details on the GitHub query syntax.
+
 
 ## Examples
 

--- a/docs/tables/github_search_topic.md
+++ b/docs/tables/github_search_topic.md
@@ -2,7 +2,7 @@
 
 The `github_search_topic` table helps to find topics via various criteria. You can search for topics on GitHub, explore related topics, and see how many repositories are associated with a certain topic.
 
- **You must always include at least one search term when searching source code** in the where or join clause using the `query` column.
+ **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. See [Searching topics](https://docs.github.com/search-github/searching-on-github/searching-topics) for details on the GitHub query syntax.
 
 ## Examples
 

--- a/docs/tables/github_search_user.md
+++ b/docs/tables/github_search_user.md
@@ -2,7 +2,8 @@
 
 The `github_search_user` table helps to find users and organizations via various criteria. You can filter your search to the personal user or organization account name with `user` or `org` qualifiers.
 
- **You must always include at least one search term when searching source code** in the where or join clause using the `query` column.
+ **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. See [Searching users](https://docs.github.com/search-github/searching-on-github/searching-users) for details on the GitHub query syntax.
+ 
 
 ## Examples
 

--- a/docs/tables/github_search_user.md
+++ b/docs/tables/github_search_user.md
@@ -3,7 +3,6 @@
 The `github_search_user` table helps to find users and organizations via various criteria. You can filter your search to the personal user or organization account name with `user` or `org` qualifiers.
 
  **You must always include at least one search term when searching source code** in the where or join clause using the `query` column. See [Searching users](https://docs.github.com/search-github/searching-on-github/searching-users) for details on the GitHub query syntax.
- 
 
 ## Examples
 


### PR DESCRIPTION
@cbruno10 I've closed #163 in favor of this PR. 

The outlier is `github_search_label` which doesn't have a corresponding GH doc page. Left that alone for now.

