### PR TITLE
Add column `security` to table `github_community_profile` Closes #179

### DIFF
--- a/docs/tables/github_community_profile.md
+++ b/docs/tables/github_community_profile.md
@@ -25,7 +25,8 @@ where
 ```sql
 select 
   repository_full_name, 
-  jsonb_pretty(security) as security 
+  security ->> 'html_url' as security_file_url,
+  security ->> 'name' as security_file_name
 from
   github_community_profile c 
   join github_my_repository r on r.full_name = c.repository_full_name

--- a/docs/tables/github_community_profile.md
+++ b/docs/tables/github_community_profile.md
@@ -19,3 +19,15 @@ from
 where
   repository_full_name = 'turbot/steampipe';
 ```
+
+### List repositories having the security file
+
+```sql
+select 
+  repository_full_name, 
+  jsonb_pretty(security) as security 
+from
+  github_community_profile c 
+  join github_my_repository r on r.full_name = c.repository_full_name
+  where security is not null;
+```

--- a/github/table_github_community_profile.go
+++ b/github/table_github_community_profile.go
@@ -80,8 +80,15 @@ func securityFileGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 
 	optionalSecurityMDNames := []string{"SECURITY.md", "security.md", "Security.md"}
 
-	for _, optionalName := range optionalSecurityMDNames {
-		fileContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, optionalName, &github.RepositoryContentGetOptions{})
+	for _, filePath := range optionalSecurityMDNames {
+		fileContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, filePath, &github.RepositoryContentGetOptions{})
+
+		if err != nil {
+			// Gets this error of repository is not initialized
+			if strings.Contains(err.Error(), "404 This repository is empty.") {
+				return nil, nil
+			}
+		}
 
 		if fileContent != nil {
 			return fileContent, nil

--- a/github/table_github_community_profile.go
+++ b/github/table_github_community_profile.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"strings"
 
 	"github.com/google/go-github/v45/github"
 
@@ -17,8 +18,8 @@ func tableGitHubCommunityProfile(ctx context.Context) *plugin.Table {
 		Name:        "github_community_profile",
 		Description: "Community profile information for the given repository.",
 		List: &plugin.ListConfig{
-			KeyColumns: plugin.SingleColumn("repository_full_name"),
-			Hydrate:    tableGitHubCommunityProfileList,
+			KeyColumns:        plugin.SingleColumn("repository_full_name"),
+			Hydrate:           tableGitHubCommunityProfileList,
 			ShouldIgnoreError: isNotFoundError([]string{"404"}),
 		},
 		Columns: []*plugin.Column{
@@ -31,6 +32,7 @@ func tableGitHubCommunityProfile(ctx context.Context) *plugin.Table {
 			{Name: "pull_request_template", Type: proto.ColumnType_JSON, Transform: transform.FromField("Files.PullRequestTemplate"), Description: "Pull request template for the repository."},
 			{Name: "license", Type: proto.ColumnType_JSON, Transform: transform.FromField("Files.License"), Description: "License for the repository."},
 			{Name: "readme", Type: proto.ColumnType_JSON, Transform: transform.FromField("Files.Readme"), Description: "README for the repository."},
+			{Name: "security", Type: proto.ColumnType_JSON, Transform: transform.FromValue(), Description: "Security for the repository.", Hydrate: securityFileGet},
 			{Name: "updated_at", Type: proto.ColumnType_TIMESTAMP, Description: "Time when the community profile was last updated."},
 		},
 	}
@@ -67,5 +69,28 @@ func tableGitHubCommunityProfileList(ctx context.Context, d *plugin.QueryData, h
 	result := getResp.result
 
 	d.StreamListItem(ctx, result)
+	return nil, nil
+}
+
+func securityFileGet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	client := connect(ctx, d)
+
+	fullName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
+	owner, repo := parseRepoFullName(fullName)
+
+	optionalSecurityMDNames := []string{"SECURITY.md", "security.md", "Security.md"}
+
+	for _, optionalName := range optionalSecurityMDNames {
+		fileContent, _, _, err := client.Repositories.GetContents(ctx, owner, repo, optionalName, &github.RepositoryContentGetOptions{})
+
+		if fileContent != nil {
+			return fileContent, nil
+		} else if err != nil && strings.Contains(err.Error(), "Not Found") {
+			return nil, nil
+		} else if err != nil {
+			plugin.Logger(ctx).Error("github_community_profile.securityFileGet", "api_error", err)
+			return nil, err
+		}
+	}
 	return nil, nil
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select 
  repository_full_name, 
  security ->> 'html_url' as security_file_url,
  security ->> 'name' as security_file_name
from
  github_community_profile c 
  join github_my_repository r on r.full_name = c.repository_full_name
  where security is not null;
+-----------------------------------+----------------------------------------------------------------------------+--------------------+
| repository_full_name              | security_file_url                                                          | security_file_name |
+-----------------------------------+----------------------------------------------------------------------------+--------------------+
| turbot/steampipe                  | https://github.com/turbot/steampipe/blob/main/SECURITY.md                  | SECURITY.md        |
| turbot/steampipe-plugin-aws       | https://github.com/turbot/steampipe-plugin-aws/blob/main/SECURITY.md       | SECURITY.md        |
| turbot/steampipe-plugin-azuread   | https://github.com/turbot/steampipe-plugin-azuread/blob/main/SECURITY.md   | SECURITY.md        |
| turbot/steampipe-plugin-bitbucket | https://github.com/turbot/steampipe-plugin-bitbucket/blob/main/SECURITY.md | SECURITY.md        |
| turbot/steampipe-plugin-okta      | https://github.com/turbot/steampipe-plugin-okta/blob/main/SECURITY.md      | SECURITY.md        |
| turbot/steampipe-plugin-oci       | https://github.com/turbot/steampipe-plugin-oci/blob/main/SECURITY.md       | SECURITY.md        |
+-----------------------------------+----------------------------------------------------------------------------+--------------------+
```
</details>
