### PR TITLE
`github_commit` fails when there is no commit or repo is empty. Fixes #181

### DIFF
--- a/github/table_github_commit.go
+++ b/github/table_github_commit.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v45/github"
@@ -119,7 +120,10 @@ func tableGitHubCommitList(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	for {
 		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
 		if err != nil {
-			return nil, err
+			// Gets this error if repository is not initialized
+			if strings.Contains(err.Error(), "409 Git Repository is empty.") {
+				return nil, nil
+			}
 		}
 
 		listResponse := listPageResponse.(ListPageResponse)


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from github_commit where repository_full_name = 'rajmohanty/onlyissue'
+----------------------+-----+--------------+-------------+----------+--------------+--------+-----------------+----------------+-------+----------+---------+---------+---------+-------+-----+------+
| repository_full_name | sha | author_login | author_date | verified | comments_url | commit | committer_login | committer_date | files | html_url | message | node_id | parents | stats | url | _ctx |
+----------------------+-----+--------------+-------------+----------+--------------+--------+-----------------+----------------+-------+----------+---------+---------+---------+-------+-----+------+
+----------------------+-----+--------------+-------------+----------+--------------+--------+-----------------+----------------+-------+----------+---------+---------+---------+-------+-----+------+

Time: 1691.5ms.
```
</details>
