### PR TITLE
Fix typo in github_branch_protection table

### DIFF
--- a/docs/tables/github_branch_protection.md
+++ b/docs/tables/github_branch_protection.md
@@ -31,7 +31,7 @@ where
   and name = 'main';
 ```
 
-## Get repositories where coversation resolution is required for merging
+## Get repositories where conversation resolution is required for merging
 
 ```sql
 select 

--- a/docs/tables/github_workflow.md
+++ b/docs/tables/github_workflow.md
@@ -38,5 +38,5 @@ from
   pipelines as p,
   jsonb_array_elements(pipeline -> 'jobs') as j
 where
-  (j -> 'metadata' -> 'build')::bool
+  (j -> 'metadata' -> 'build')::bool;
 ```


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
