### PR TITLE
Add `github_tree` table

### DIFF
--- a/docs/tables/github_tree.md
+++ b/docs/tables/github_tree.md
@@ -1,0 +1,88 @@
+# Table: github_tree
+
+A Git tree object creates the hierarchy between files in a Git repository. You
+can use the Git tree object to create the relationship between directories and
+the files they contain.
+
+A single tree object contains one or more entries, each of which is the SHA-1
+hash of a blob or subtree with its associated mode, type, and filename.
+
+The `github_tree` table can be used to query information about any tree, and
+**you must specify which repository and tree SHA** in the where or join clause
+using the `repository_full_name` and `tree_sha` columns. By default, recursive
+entries are not returned, but can be with the `recursive` column.
+
+## Examples
+
+### List tree entries non-recursively
+
+```sql
+select
+  tree_sha,
+  truncated,
+  path,
+  mode,
+  type,
+  sha
+from
+  github_tree
+where
+  repository_full_name = 'turbot/steampipe'
+  and tree_sha = '0f200416c44b8b85277d973bff933efa8ef7803a';
+```
+
+### List tree entries for a subtree recursively
+
+```sql
+select
+  tree_sha,
+  truncated,
+  path,
+  mode,
+  type,
+  sha
+from
+  github_tree
+where
+  repository_full_name = 'turbot/steampipe'
+  and tree_sha = '5622172b528cd38438c52ecfa3c20ac3f71dd2df'
+  and recursive = true;
+```
+
+### List executable files
+
+```sql
+select
+  tree_sha,
+  truncated,
+  path,
+  mode,
+  size,
+  sha
+from
+  github_tree
+where
+  repository_full_name = 'turbot/steampipe'
+  and tree_sha = '0f200416c44b8b85277d973bff933efa8ef7803a'
+  and recursive = true
+  and mode = '100755';
+```
+
+### List JSON files
+
+```sql
+select
+  tree_sha,
+  truncated,
+  path,
+  mode,
+  size,
+  sha
+from
+  github_tree
+where
+  repository_full_name = 'turbot/steampipe'
+  and tree_sha = '0f200416c44b8b85277d973bff933efa8ef7803a'
+  and recursive = true
+  and path like '%.json';
+```

--- a/github/plugin.go
+++ b/github/plugin.go
@@ -57,6 +57,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"github_team":                            tableGitHubTeam(),
 			"github_traffic_view_daily":              tableGitHubTrafficViewDaily(ctx),
 			"github_traffic_view_weekly":             tableGitHubTrafficViewWeekly(ctx),
+			"github_tree":                            tableGitHubTree(ctx),
 			"github_user":                            tableGitHubUser(),
 			"github_workflow":                        tableGitHubWorkflow(ctx),
 		},

--- a/github/table_github_tree.go
+++ b/github/table_github_tree.go
@@ -1,0 +1,87 @@
+package github
+
+import (
+	"context"
+
+	"github.com/google/go-github/v33/github"
+
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableGitHubTree(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "github_tree",
+		Description: "Tree in the given repository, lists files in the git tree",
+		Get: &plugin.GetConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "repository_full_name", Require: plugin.Required},
+				{Name: "tree_sha", Require: plugin.Required},
+				{Name: "recursive", Require: plugin.Optional},
+			},
+			ShouldIgnoreError: isNotFoundError([]string{"404"}),
+			Hydrate:           tableGitHubTreeGet,
+		},
+		Columns: []*plugin.Column{
+			// Top columns
+			{Name: "repository_full_name", Type: proto.ColumnType_STRING, Transform: transform.FromQual("repository_full_name"), Description: "Full name of the repository"},
+			{Name: "tree_sha", Type: proto.ColumnType_STRING, Transform: transform.FromQual("tree_sha"), Description: "Tree SHA"},
+			{Name: "recursive", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("recursive"), Description: "Recursive tree content"},
+			{Name: "truncated", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Truncated"), Description: "Whether results are truncated"},
+			{Name: "entries", Type: proto.ColumnType_JSON, Transform: transform.FromField("Entries"), Description: "Tree entries"},
+		},
+	}
+}
+
+//// GET FUNCTION
+
+func tableGitHubTreeGet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("Connecting to client")
+	client := connect(ctx, d)
+
+	if h.Item != nil {
+		item := h.Item
+		logger.Trace("Got hydrate data", item)
+	} else {
+		logger.Trace("No hydrate data")
+	}
+	quals := d.KeyColumnQuals
+	logger.Trace("Parsing key column quals", quals)
+	fullName := quals["repository_full_name"].GetStringValue()
+	sha := quals["tree_sha"].GetStringValue()
+	recursive := quals["recursive"].GetBoolValue()
+	owner, repo := parseRepoFullName(fullName)
+
+	type GetResponse struct {
+		tree *github.Tree
+		resp *github.Response
+	}
+
+	getTree := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+		logger.Trace("Getting tree", "owner", owner, "repo", repo, "sha", sha)
+		tree, resp, err := client.Git.GetTree(ctx, owner, repo, sha, recursive)
+		return GetResponse{
+			tree: tree,
+			resp: resp,
+		}, err
+	}
+	getResponse, err := plugin.RetryHydrate(ctx, d, h, getTree, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+
+	if err != nil {
+		logger.Error("Error getting tree", err)
+		return nil, err
+	}
+
+	getResp := getResponse.(GetResponse)
+	tree := getResp.tree
+	if tree != nil {
+		logger.Trace("Returning tree", tree)
+		return tree, nil
+	}
+	logger.Error("Nothing found")
+	return nil, nil
+}

--- a/github/table_github_tree.go
+++ b/github/table_github_tree.go
@@ -3,11 +3,11 @@ package github
 import (
 	"context"
 
-	"github.com/google/go-github/v33/github"
+	"github.com/google/go-github/v45/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
 )
 
 //// TABLE DEFINITION
@@ -16,22 +16,28 @@ func tableGitHubTree(ctx context.Context) *plugin.Table {
 	return &plugin.Table{
 		Name:        "github_tree",
 		Description: "Tree in the given repository, lists files in the git tree",
-		Get: &plugin.GetConfig{
+		List: &plugin.ListConfig{
+			Hydrate:           tableGitHubTreeGet,
+			ShouldIgnoreError: isNotFoundError([]string{"404"}),
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "repository_full_name", Require: plugin.Required},
 				{Name: "tree_sha", Require: plugin.Required},
-				{Name: "recursive", Require: plugin.Optional},
+				{Name: "recursive", Require: plugin.Optional, CacheMatch: "exact"},
 			},
-			ShouldIgnoreError: isNotFoundError([]string{"404"}),
-			Hydrate:           tableGitHubTreeGet,
 		},
 		Columns: []*plugin.Column{
 			// Top columns
-			{Name: "repository_full_name", Type: proto.ColumnType_STRING, Transform: transform.FromQual("repository_full_name"), Description: "Full name of the repository"},
-			{Name: "tree_sha", Type: proto.ColumnType_STRING, Transform: transform.FromQual("tree_sha"), Description: "Tree SHA"},
-			{Name: "recursive", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("recursive"), Description: "Recursive tree content"},
-			{Name: "truncated", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Truncated"), Description: "Whether results are truncated"},
-			{Name: "entries", Type: proto.ColumnType_JSON, Transform: transform.FromField("Entries"), Description: "Tree entries"},
+			{Name: "repository_full_name", Type: proto.ColumnType_STRING, Transform: transform.FromQual("repository_full_name"), Description: "Full name of the repository that contains the tree."},
+			{Name: "tree_sha", Type: proto.ColumnType_STRING, Transform: transform.FromQual("tree_sha"), Description: "SHA1 of the tree."},
+			// TODO: How to handle recursive and truncated columns when splitting items?
+			{Name: "recursive", Type: proto.ColumnType_BOOL, Transform: transform.FromQual("recursive"), Description: "If set to true, return objects or subtrees referenced by the tree. Defaults to false."},
+			{Name: "truncated", Type: proto.ColumnType_BOOL, Transform: transform.FromField("Truncated"), Description: "True if the entires were truncated because the number of items in the tree exceeded Github's maximum limit."},
+			{Name: "mode", Type: proto.ColumnType_STRING, Description: "File mode, valid values are 100644 (file, blob), 100755 (executable, blob), 040000 (subdirectory, tree), 160000 (submodule, commit), 120000 (blob that specifies path of a symlink)."},
+			{Name: "path", Type: proto.ColumnType_STRING, Description: "The file referenced in the tree."},
+			{Name: "sha", Type: proto.ColumnType_STRING, Transform: transform.FromField("SHA"), Description: "SHA1 checksum ID of the object in the tree."},
+			{Name: "size", Type: proto.ColumnType_STRING, Description: "Path."},
+			{Name: "type", Type: proto.ColumnType_STRING, Description: "Type of the entry, valid values are blob, tree, or commit."},
+			{Name: "url", Type: proto.ColumnType_STRING, Transform: transform.FromField("URL"), Description: "URL to the file referenced in the tree."},
 		},
 	}
 }
@@ -40,19 +46,12 @@ func tableGitHubTree(ctx context.Context) *plugin.Table {
 
 func tableGitHubTreeGet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
-	logger.Trace("Connecting to client")
 	client := connect(ctx, d)
 
-	if h.Item != nil {
-		item := h.Item
-		logger.Trace("Got hydrate data", item)
-	} else {
-		logger.Trace("No hydrate data")
-	}
 	quals := d.KeyColumnQuals
-	logger.Trace("Parsing key column quals", quals)
 	fullName := quals["repository_full_name"].GetStringValue()
 	sha := quals["tree_sha"].GetStringValue()
+
 	recursive := quals["recursive"].GetBoolValue()
 	owner, repo := parseRepoFullName(fullName)
 
@@ -62,7 +61,6 @@ func tableGitHubTreeGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	}
 
 	getTree := func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-		logger.Trace("Getting tree", "owner", owner, "repo", repo, "sha", sha)
 		tree, resp, err := client.Git.GetTree(ctx, owner, repo, sha, recursive)
 		return GetResponse{
 			tree: tree,
@@ -72,16 +70,17 @@ func tableGitHubTreeGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	getResponse, err := plugin.RetryHydrate(ctx, d, h, getTree, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
 
 	if err != nil {
-		logger.Error("Error getting tree", err)
+		logger.Error("github_tree.tableGitHubTreeGet", "api_error", err)
 		return nil, err
 	}
 
 	getResp := getResponse.(GetResponse)
 	tree := getResp.tree
-	if tree != nil {
-		logger.Trace("Returning tree", tree)
-		return tree, nil
+	entries := tree.Entries
+
+	for _, entry := range entries {
+		d.StreamListItem(ctx, entry)
 	}
-	logger.Error("Nothing found")
+
 	return nil, nil
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  tree_sha,
  truncated,
  path,
  mode,
  size,
  sha
from
  github_tree
where
  repository_full_name = 'turbot/steampipe'
  and tree_sha = '0f200416c44b8b85277d973bff933efa8ef7803a'
  and recursive = true
  and path like '%.json';
+------------------------------------------+-----------+---------------------------------------------------------------------------+--------+--------+------------------------------------------+
| tree_sha                                 | truncated | path                                                                      | mode   | size   | sha                                      |
+------------------------------------------+-----------+---------------------------------------------------------------------------+--------+--------+------------------------------------------+
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | .github/actions/semver-tags/package.json                                  | 100644 | 337    | 39a23e0c69991d63a0683ce857b592c657f148af |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | .github/actions/semver-tags/package-lock.json                             | 100644 | 8104   | 80a647ab986cef47962c4dc57218155cf6ba5bbe |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/control/controldisplay/templates/json/version.json                    | 100644 | 24     | 688e939808b0bf8c432ef202b337538a1a82607d |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/control/controldisplay/templates/nunit3.xml/version.json              | 100644 | 24     | 688e939808b0bf8c432ef202b337538a1a82607d |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/control/controldisplay/templates/html/version.json                    | 100644 | 24     | 688e939808b0bf8c432ef202b337538a1a82607d |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/control/controldisplay/templates/md/version.json                      | 100644 | 24     | 688e939808b0bf8c432ef202b337538a1a82607d |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/control/controldisplay/templates/asff.json/version.json               | 100644 | 24     | 688e939808b0bf8c432ef202b337538a1a82607d |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/control/controldisplay/templates/asff.json                            | 040000 | <null> | 49c426522871c3b5778d2ed2a995e2c97e187904 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/control/controldisplay/templates/csv/version.json                     | 100644 | 24     | 688e939808b0bf8c432ef202b337538a1a82607d |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/steampipeconfig/testdata/manual testing /report/.mod.cache.json       | 100644 | 194    | c98437726bc9264a592d19cd8988529f90fa2c06 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/workspace/test_data/dependent_mod/.mod.cache.json                     | 100644 | 233    | 4fc7c53c560a6c0adb914a4ff93c61c075d6152c |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/workspace/test_data/dependent_mod_2/.mod.cache.json                   | 100644 | 233    | 4fc7c53c560a6c0adb914a4ff93c61c075d6152c |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/dependent_mod_with_variables/.mod.cache.json   | 100644 | 233    | 4fc7c53c560a6c0adb914a4ff93c61c075d6152c |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/dependent_mod_with_legacy_lock/.mod.cache.json | 100644 | 199    | cb7f95bc4ca535bdb427a2f3c97860eb4dfb31f1 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/source_files/chaos2.json                       | 100644 | 157    | c583f34f9f15e627cbb876acafb1b96e92f99325 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/source_files/chaos.json                        | 100644 | 408    | 5980e05e1871fc5e9014e05438072c130f40d7e2 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/source_files/chaos_options.json                | 100644 | 254    | 9e6ff1942b11b21ddc11a2333aa5ae4db7073e69 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_6.json                      | 100644 | 1157   | ea8c3f462ecbf083c97c8dbb6664736f54058492 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_query_json.json             | 100644 | 32     | 2219c5722f65028aa84a75e300bbbc033a526c84 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_check_all.json              | 100644 | 2775   | 15202fd115ddbcee9afd2fe66454fd68f99fdb94 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_check_json.json             | 100644 | 6076   | 9483c9c9707f50fc071088e874a3683de8b4707d |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_json.json                   | 100644 | 236    | 59b9b0af9a627b8b35b339ae0152db4e3d821225 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/source_files/chaos_options_2.json              | 100644 | 255    | 61d09a6e6fedd5ae139266ed27c408280d369bb7 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_1.json                      | 100644 | 3610   | affc82d8bbab8be495481add62858ccf84448a39 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_11.json                     | 100644 | 771    | 0414712d410fa389d07b77511bf2c388d25506b0 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_12.json                     | 100644 | 104    | 3aada0e3be2a60c988b5582ab67b34d7a20ebb94 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_13.json                     | 100644 | 38     | 523f2cbbba9c110fff352c63c20c0875ca4f1a52 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_14.json                     | 100644 | 115    | e4ecb210388e6cceee9d415dbb44ce908e990b72 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_15.json                     | 100644 | 21     | 93f1517021cb25b7470721e8e9466dc707766320 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_2.json                      | 100644 | 262    | dfa8113ad8dfd0ec95a42e1c469e2afbb955e4c6 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_5.json                      | 100644 | 304    | c1eba911fa6c37d77d50978a9646a68c0b500537 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/test_data/templates/expected_3.json                      | 100644 | 7      | 35339670342116ab7f77d681463bb5e08a7802f0 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | ui/dashboard/package.json                                                 | 100644 | 3104   | ea2d8bd01a75d8fb5927af760be5af5e6366b010 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | ui/dashboard/public/manifest.json                                         | 100644 | 306    | 1f2f141fafdeb1d31d85b008ec5132840c5e6362 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | ui/dashboard/tsconfig.json                                                | 100644 | 172    | 3e6ca28cc6f30a51fec46d19d8878ebf1892091a |
+------------------------------------------+-----------+---------------------------------------------------------------------------+--------+--------+------------------------------------------+
> select
  tree_sha,
  truncated,
  path,
  mode,
  size,
  sha
from
  github_tree
where
  repository_full_name = 'turbot/steampipe'
  and tree_sha = '0f200416c44b8b85277d973bff933efa8ef7803a'
  and recursive = true
  and mode = '100755';
+------------------------------------------+-----------+-----------------------------------------------------------------------+--------+------+------------------------------------------+
| tree_sha                                 | truncated | path                                                                  | mode   | size | sha                                      |
+------------------------------------------+-----------+-----------------------------------------------------------------------+--------+------+------------------------------------------+
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | .github/actions/semver-tags/build.sh                                  | 100755 | 19   | 8c7450e3c8148ecaba68b3d50a705e2b0ec339b4 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | docker-entrypoint.sh                                                  | 100755 | 323  | 587034ef391dfc104fa9ebfe6be1ebeaa05caa56 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | install.sh                                                            | 100755 | 3425 | fe59e92813c651f73583191d397763c1f576c65a |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg/steampipeconfig/testdata/connections_to_update/config/default.spc | 100755 | 918  | 4ba567ffd3f86d89f9df11d3982ba0b2a9a8139a |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/run-local.sh                                         | 100755 | 379  | 9b013378b00b2f25c36bc0e73380fc378899f77f |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/acceptance/run.sh                                               | 100755 | 2360 | a89b038daa84e080cf8f605e3beb7f2139e29a46 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/dockertesting/debian/run-tests.sh                               | 100755 | 365  | 42e8caff7d64c86fbfa2fd06d800cbed0245f3b0 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests/dockertesting/oraclelinux/run-tests.sh                          | 100755 | 365  | 42e8caff7d64c86fbfa2fd06d800cbed0245f3b0 |
+------------------------------------------+-----------+-----------------------------------------------------------------------+--------+------+------------------------------------------+
> select
  tree_sha,
  truncated,
  path,
  mode,
  type,
  sha
from
  github_tree
where
  repository_full_name = 'turbot/steampipe'
  and tree_sha = '5622172b528cd38438c52ecfa3c20ac3f71dd2df'
  and recursive = true;
+------------------------------------------+-----------+--------------------------------------+--------+------+------------------------------------------+
| tree_sha                                 | truncated | path                                 | mode   | type | sha                                      |
+------------------------------------------+-----------+--------------------------------------+--------+------+------------------------------------------+
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc                                 | 040000 | tree | 24beda70db7d8ce18d03cb2c573fae2e27c7c718 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | state.go                             | 100644 | blob | 60c8bd6a308a676d78b3dd71eaf50fd9ff132411 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/proto                           | 040000 | tree | ffefb6297f8431d48aa2f5e1c9a8adb507580a04 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/proto/reattach_config.go        | 100644 | blob | 11d7384991c0b2d79a5983941bdcc1a9eaf8fe58 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/proto/plugin_manager_grpc.pb.go | 100644 | blob | 8e93471c9622efad04bd84bc98bf167da40242bf |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | Makefile                             | 100644 | blob | 812070f905f108c34d25e845af82c4c3b9ecf465 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/proto/plugin_manager.proto      | 100644 | blob | 9f5933cfd96268271121dfc6746e2a95533581d5 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/proto/simple_addr.go            | 100644 | blob | 589369f44354d83f5e8ec22b95626f4d065701ec |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | plugin_manager.go                    | 100644 | blob | 260307ad8396777c2ba8e0b3e3f014187b61d000 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/shared                          | 040000 | tree | ef0e14027a559fa7b39ee67fc8fd1734c26a24f3 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/shared/interface.go             | 100644 | blob | 52657021c65ba1f3c85248eb457eb05045a0c817 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/proto/plugin_manager.pb.go      | 100644 | blob | 52d27da41cbc13bad6c675b4e2b289ab6bc2269a |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | lifecycle.go                         | 100644 | blob | ac67bede3e58e667933d04d90efb642553e334e0 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | plugin_path.go                       | 100644 | blob | 3e36467e095bc6421b023ee4483367567d63bb26 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | plugin_manager_client.go             | 100644 | blob | 32184dd931b568f96ff8047d2ec0becf4d3f1761 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/proto/supported_operations.go   | 100644 | blob | 0b6dabc75312a2d31be63341546183c43a20ae69 |
| 5622172b528cd38438c52ecfa3c20ac3f71dd2df | false     | grpc/shared/grpc.go                  | 100644 | blob | 375e17c41ab498d2772de9baea4b130284165742 |
+------------------------------------------+-----------+--------------------------------------+--------+------+------------------------------------------+
> select
  tree_sha,
  truncated,
  path,
  mode,
  type,
  sha
from
  github_tree
where
  repository_full_name = 'turbot/steampipe'
  and tree_sha = '0f200416c44b8b85277d973bff933efa8ef7803a';
+------------------------------------------+-----------+----------------------+--------+------+------------------------------------------+
| tree_sha                                 | truncated | path                 | mode   | type | sha                                      |
+------------------------------------------+-----------+----------------------+--------+------+------------------------------------------+
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | .golangci.yml        | 100644 | blob | 317c89ad2485fa15b5c2f3d52f484f425ee6863a |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | CODE_OF_CONDUCT.md   | 100644 | blob | 66bac0539a978d9a56b4701fcee7f5c671608d08 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | .gitignore           | 100644 | blob | f649a283ce89a2d1feac4b3ef11bc89bcf14fc70 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | SECURITY.md          | 100644 | blob | 1da4ddae96ee2735c4d2a2ed6d43596f94469d5e |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | LICENSE              | 100644 | blob | 0ad25db4bd1d86c452db3f9602ccdbe172438f52 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | .gitattributes       | 100644 | blob | 03c4f49de0c22c9840eacd0373d1b526f49a09e8 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | Dockerfile           | 100644 | blob | d52d20ae10962be169f34375621952553f5a770d |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | .goreleaser.yml      | 100644 | blob | 924ce6c38d2786a591e115059cbddeb9c68b7dd2 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | README.md            | 100644 | blob | ba74019a8118d0ea34d072e7ceb7c9be99239a91 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | main.go              | 100644 | blob | d1760afbd89784fd4b72b0cdcdbcfa3982351752 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | CHANGELOG.md         | 100644 | blob | 557d7ec32c769b0c01c540eb6afd4ffdd898be75 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | Makefile             | 100644 | blob | 4650745ea73b4769919e29f3882a05d1351e2212 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | docker-entrypoint.sh | 100755 | blob | 587034ef391dfc104fa9ebfe6be1ebeaa05caa56 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | .gitmodules          | 100644 | blob | 67471a529455bf19af15d41edddc75df766d9d7e |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | ui                   | 040000 | tree | a98e9bbf02b30728b02195a54ce07169af8fb315 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | install.sh           | 100755 | blob | fe59e92813c651f73583191d397763c1f576c65a |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pkg                  | 040000 | tree | 57c1287ef7c717491fc650e6c0f7397ab1e13a8f |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | cmd                  | 040000 | tree | b5f452ad66361d7af196b5d4ada4f099efd8d788 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | CONTRIBUTING.md      | 100644 | blob | a2524cceebc3aa610fb0acf8d5579b7bbbce508c |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | go.mod               | 100644 | blob | 0bb69a48a873fe603da6b88b5991bfca329b7d02 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | pluginmanager        | 040000 | tree | 5622172b528cd38438c52ecfa3c20ac3f71dd2df |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | go.sum               | 100644 | blob | aca288c11ede29f54bca1eeda81675bf687f1547 |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | tests                | 040000 | tree | 848e78aa5a790e76169e748fbd00e8325278d57f |
| 0f200416c44b8b85277d973bff933efa8ef7803a | false     | .github              | 040000 | tree | 4191397c04323682081c54d87d72a99418f879c9 |
+------------------------------------------+-----------+----------------------+--------+------+------------------------------------------+
```
</details>
