### PR TITLE
Update error retry logic to use exponential backoff and longer intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,25 @@
 
 ## Quick start
 
-Install the plugin with [Steampipe](https://steampipe.io):
+Install the plugin with [Steampipe](https://steampipe.io/downloads):
 
 ```shell
 steampipe plugin install github
 ```
 
-Set your GitHub API key:
+[Configure the plugin](https://hub.steampipe.io/plugins/turbot/github#configuration) using the configuration file:
 
 ```shell
-export GITHUB_TOKEN=YOURTOKENHERE
+vi ~/.steampipe/github.spc
 ```
 
-Launch the Steampipe REPL:
+Or environment variables:
+
+```shell
+export GITHUB_TOKEN=ghp_YOURTOKENHERE
+```
+
+Start Steampipe:
 
 ```shell
 steampipe query

--- a/github/errors.go
+++ b/github/errors.go
@@ -10,11 +10,6 @@ import (
 )
 
 func shouldRetryError(ctx context.Context, err error) bool {
-	if _, ok := err.(*github.RateLimitError); ok {
-		plugin.Logger(ctx).Debug("errors.shouldRetryError", "rate_limit_error", err, "rate", err.(*github.RateLimitError).Rate)
-		return false
-	}
-
 	if _, ok := err.(*github.AbuseRateLimitError); ok {
 		var retryAfter *time.Duration
 		if err.(*github.AbuseRateLimitError).RetryAfter != nil {
@@ -24,10 +19,6 @@ func shouldRetryError(ctx context.Context, err error) bool {
 		return true
 	}
 
-	if _, ok := err.(*github.AbuseRateLimitError); ok {
-		log.Printf("[WARN] Received Secondary Rate Limit Error")
-		return true
-	}
 	return false
 }
 

--- a/github/errors.go
+++ b/github/errors.go
@@ -1,16 +1,26 @@
 package github
 
 import (
-	"log"
+	"context"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v45/github"
 	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
 )
 
-func shouldRetryError(err error) bool {
+func shouldRetryError(ctx context.Context, err error) bool {
 	if _, ok := err.(*github.RateLimitError); ok {
-		log.Printf("[WARN] Received Rate Limit Error")
+		plugin.Logger(ctx).Debug("errors.shouldRetryError", "rate_limit_error", err, "rate", err.(*github.RateLimitError).Rate)
+		return false
+	}
+
+	if _, ok := err.(*github.AbuseRateLimitError); ok {
+		var retryAfter *time.Duration
+		if err.(*github.AbuseRateLimitError).RetryAfter != nil {
+			retryAfter = err.(*github.AbuseRateLimitError).RetryAfter
+		}
+		plugin.Logger(ctx).Debug("errors.shouldRetryError", "abuse_rate_limit_error", err, "retryAfter", retryAfter)
 		return true
 	}
 	return false

--- a/github/table_github_actions_artifact.go
+++ b/github/table_github_actions_artifact.go
@@ -74,7 +74,7 @@ func tableGitHubArtifactList(ctx context.Context, d *plugin.QueryData, h *plugin
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			return nil, err
 		}
@@ -133,7 +133,7 @@ func tableGitHubArtifactGet(ctx context.Context, d *plugin.QueryData, h *plugin.
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_actions_repository_runner.go
+++ b/github/table_github_actions_repository_runner.go
@@ -70,7 +70,7 @@ func tableGitHubRunnerList(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			return nil, err
 		}
@@ -129,7 +129,7 @@ func tableGitHubRunnerGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_actions_repository_secret.go
+++ b/github/table_github_actions_repository_secret.go
@@ -31,7 +31,7 @@ func tableGitHubActionsRepositorySecret(ctx context.Context) *plugin.Table {
 			{Name: "repository_full_name", Type: proto.ColumnType_STRING, Transform: transform.FromQual("repository_full_name"), Description: "Full name of the repository that contains the secrets."},
 			{Name: "name", Type: proto.ColumnType_STRING, Description: "The name of the secret."},
 			{Name: "visibility", Type: proto.ColumnType_STRING, Description: "The visibility of the secret."},
-			{Name: "selected_repositories_url", Type: proto.ColumnType_STRING, Transform: transform.FromField("SelectedRepositoriesURL"),Description: "The GitHub URL of the repository."},
+			{Name: "selected_repositories_url", Type: proto.ColumnType_STRING, Transform: transform.FromField("SelectedRepositoriesURL"), Description: "The GitHub URL of the repository."},
 
 			// Other columns
 			{Name: "created_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("CreatedAt").Transform(convertTimestamp), Description: "Time when the secret was created."},
@@ -71,7 +71,7 @@ func tableGitHubRepoSecretList(ctx context.Context, d *plugin.QueryData, h *plug
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			return nil, err
 		}
@@ -106,7 +106,7 @@ func tableGitHubRepoSecretList(ctx context.Context, d *plugin.QueryData, h *plug
 func tableGitHubRepoSecretGet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	name := d.KeyColumnQuals["name"].GetStringValue()
 	orgName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
-	
+
 	// Empty check for the parameters
 	if name == "" || orgName == "" {
 		return nil, nil
@@ -129,7 +129,7 @@ func tableGitHubRepoSecretGet(ctx context.Context, d *plugin.QueryData, h *plugi
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_actions_repository_workflow_run.go
+++ b/github/table_github_actions_repository_workflow_run.go
@@ -124,7 +124,7 @@ func tableGitHubRepoWorkflowRunList(ctx context.Context, d *plugin.QueryData, h 
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			return nil, err
 		}
@@ -158,7 +158,7 @@ func tableGitHubRepoWorkflowRunList(ctx context.Context, d *plugin.QueryData, h 
 func tableGitHubRepoWorkflowRunGet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	runId := d.KeyColumnQuals["id"].GetInt64Value()
 	orgName := d.KeyColumnQuals["repository_full_name"].GetStringValue()
-	
+
 	// Empty check for the parameters
 	if runId == 0 || orgName == "" {
 		return nil, nil
@@ -182,7 +182,7 @@ func tableGitHubRepoWorkflowRunGet(ctx context.Context, d *plugin.QueryData, h *
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -116,7 +116,7 @@ func tableGitHubAuditLogList(ctx context.Context, d *plugin.QueryData, h *plugin
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err

--- a/github/table_github_branch.go
+++ b/github/table_github_branch.go
@@ -66,7 +66,7 @@ func tableGitHubBranchList(ctx context.Context, d *plugin.QueryData, h *plugin.H
 		}, err
 	}
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			return nil, err
 		}

--- a/github/table_github_branch_protection.go
+++ b/github/table_github_branch_protection.go
@@ -87,7 +87,7 @@ func tableGitHubRepositoryBranchProtectionGet(ctx context.Context, d *plugin.Que
 		}, err
 	}
 
-	getDetails, err := plugin.RetryHydrate(ctx, d, h, get, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getDetails, err := retryHydrate(ctx, d, h, get)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func repositorySignaturesProtectedBranchGet(ctx context.Context, d *plugin.Query
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_commit.go
+++ b/github/table_github_commit.go
@@ -118,7 +118,7 @@ func tableGitHubCommitList(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			// Gets this error if repository is not initialized
 			if strings.Contains(err.Error(), "409 Git Repository is empty.") {
@@ -195,7 +195,7 @@ func tableGitHubCommitGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_community_profile.go
+++ b/github/table_github_community_profile.go
@@ -59,7 +59,7 @@ func tableGitHubCommunityProfileList(ctx context.Context, d *plugin.QueryData, h
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_gist.go
+++ b/github/table_github_gist.go
@@ -72,7 +72,7 @@ func tableGitHubGistList(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_gitignore.go
+++ b/github/table_github_gitignore.go
@@ -49,7 +49,7 @@ func tableGitHubGitignoreList(ctx context.Context, d *plugin.QueryData, h *plugi
 		}, err
 	}
 
-	listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func tableGitHubGitignoreGetData(ctx context.Context, d *plugin.QueryData, h *pl
 			resp:      resp,
 		}, err
 	}
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_issue.go
+++ b/github/table_github_issue.go
@@ -139,7 +139,7 @@ func tableGitHubRepositoryIssueList(ctx context.Context, d *plugin.QueryData, h 
 		}, err
 	}
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err
@@ -206,7 +206,7 @@ func tableGitHubRepositoryIssueGet(ctx context.Context, d *plugin.QueryData, h *
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_license.go
+++ b/github/table_github_license.go
@@ -63,7 +63,7 @@ func tableGitHubLicenseList(ctx context.Context, d *plugin.QueryData, h *plugin.
 		}, err
 	}
 
-	listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 	listResponse := listPageResponse.(ListPageResponse)
 	licenses := listResponse.licenses
@@ -115,7 +115,7 @@ func tableGitHubLicenseGetData(ctx context.Context, d *plugin.QueryData, h *plug
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_my_gist.go
+++ b/github/table_github_my_gist.go
@@ -49,7 +49,7 @@ func tableGitHubMyGistList(ctx context.Context, d *plugin.QueryData, h *plugin.H
 
 	for {
 
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err

--- a/github/table_github_my_issue.go
+++ b/github/table_github_my_issue.go
@@ -74,7 +74,7 @@ func tableGitHubMyIssueList(ctx context.Context, d *plugin.QueryData, h *plugin.
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			return nil, err
 		}

--- a/github/table_github_my_organization.go
+++ b/github/table_github_my_organization.go
@@ -48,7 +48,7 @@ func tableGitHubMyOrganizationList(ctx context.Context, d *plugin.QueryData, h *
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err

--- a/github/table_github_my_repository.go
+++ b/github/table_github_my_repository.go
@@ -60,7 +60,7 @@ func tableGitHubMyRepositoryList(ctx context.Context, d *plugin.QueryData, h *pl
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err

--- a/github/table_github_my_star.go
+++ b/github/table_github_my_star.go
@@ -54,7 +54,7 @@ func tableGitHubMyStarredRepositoryList(ctx context.Context, d *plugin.QueryData
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err

--- a/github/table_github_my_team.go
+++ b/github/table_github_my_team.go
@@ -53,7 +53,7 @@ func tableGitHubMyTeamList(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err

--- a/github/table_github_organization.go
+++ b/github/table_github_organization.go
@@ -133,7 +133,7 @@ func getOrganizationDetail(ctx context.Context, d *plugin.QueryData, h *plugin.H
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		plugin.Logger(ctx).Error("getOrganizationDetail", err)
@@ -177,7 +177,7 @@ func tableGitHubOrganizationMembersGet(ctx context.Context, d *plugin.QueryData,
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err
@@ -220,7 +220,7 @@ func organizationHooksGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil && strings.Contains(err.Error(), "Not Found") {
 			return nil, nil
 		} else if err != nil {

--- a/github/table_github_organization_member.go
+++ b/github/table_github_organization_member.go
@@ -91,7 +91,7 @@ func tableGitHubOrganizationMemberList(ctx context.Context, d *plugin.QueryData,
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			return nil, err
 		}
@@ -138,7 +138,7 @@ func tableGitHubOrganizationMemberGet(ctx context.Context, d *plugin.QueryData, 
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_pull_request.go
+++ b/github/table_github_pull_request.go
@@ -126,7 +126,7 @@ func tableGitHubPullRequestList(ctx context.Context, d *plugin.QueryData, h *plu
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err
@@ -188,7 +188,7 @@ func tableGitHubPullRequestGet(ctx context.Context, d *plugin.QueryData, h *plug
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_rate_limit.go
+++ b/github/table_github_rate_limit.go
@@ -45,7 +45,7 @@ func listGitHubRateLimit(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_release.go
+++ b/github/table_github_release.go
@@ -85,7 +85,7 @@ func tableGitHubReleaseList(ctx context.Context, d *plugin.QueryData, h *plugin.
 
 	for {
 
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err
@@ -140,7 +140,7 @@ func tableGitHubReleaseGet(ctx context.Context, d *plugin.QueryData, h *plugin.H
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_repository.go
+++ b/github/table_github_repository.go
@@ -112,7 +112,7 @@ func tableGitHubRepositoryList(ctx context.Context, d *plugin.QueryData, h *plug
 			resp: resp,
 		}, err
 	}
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func tableGitHubRepositoryGet(ctx context.Context, d *plugin.QueryData, h *plugi
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
@@ -210,7 +210,7 @@ func tableGitHubRepositoryCollaboratorsGetVariation(variant string, ctx context.
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			if strings.Contains(err.Error(), "404") {
@@ -254,7 +254,7 @@ func repositoryHooksGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil && strings.Contains(err.Error(), "Not Found") {
 			return nil, nil
 		} else if err != nil {

--- a/github/table_github_search_code.go
+++ b/github/table_github_search_code.go
@@ -81,7 +81,7 @@ func tableGitHubSearchCodeList(ctx context.Context, d *plugin.QueryData, h *plug
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			logger.Error("tableGitHubSearchCodeList", "error_RetryHydrate", err)

--- a/github/table_github_search_commit.go
+++ b/github/table_github_search_commit.go
@@ -86,7 +86,7 @@ func tableGitHubSearchCommitList(ctx context.Context, d *plugin.QueryData, h *pl
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			logger.Error("tableGitHubSearchCommitList", "error_RetryHydrate", err)

--- a/github/table_github_search_issue.go
+++ b/github/table_github_search_issue.go
@@ -105,7 +105,7 @@ func tableGitHubSearchIssueList(ctx context.Context, d *plugin.QueryData, h *plu
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			logger.Error("tableGitHubSearchIssueList", "error_RetryHydrate", err)

--- a/github/table_github_search_label.go
+++ b/github/table_github_search_label.go
@@ -86,7 +86,7 @@ func tableGitHubSearchLabelList(ctx context.Context, d *plugin.QueryData, h *plu
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			logger.Error("tableGitHubSearchLabelList", "error_RetryHydrate", err)

--- a/github/table_github_search_pull_request.go
+++ b/github/table_github_search_pull_request.go
@@ -106,7 +106,7 @@ func tableGitHubSearchPullRequestList(ctx context.Context, d *plugin.QueryData, 
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			logger.Error("tableGitHubSearchPullRequestList", "error_RetryHydrate", err)

--- a/github/table_github_search_repository.go
+++ b/github/table_github_search_repository.go
@@ -74,7 +74,7 @@ func tableGitHubSearchRepositoryList(ctx context.Context, d *plugin.QueryData, h
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			logger.Error("tableGitHubSearchRepositoryList", "error_RetryHydrate", err)

--- a/github/table_github_search_topic.go
+++ b/github/table_github_search_topic.go
@@ -83,7 +83,7 @@ func tableGitHubSearchTopicList(ctx context.Context, d *plugin.QueryData, h *plu
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			logger.Error("tableGitHubSearchTopicList", "error_RetryHydrate", err)

--- a/github/table_github_search_user.go
+++ b/github/table_github_search_user.go
@@ -116,7 +116,7 @@ func tableGitHubSearchUserList(ctx context.Context, d *plugin.QueryData, h *plug
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			logger.Error("tableGitHubSearchUserList", "error_RetryHydrate", err)

--- a/github/table_github_stargazer.go
+++ b/github/table_github_stargazer.go
@@ -62,7 +62,7 @@ func tableGitHubStargazerList(ctx context.Context, d *plugin.QueryData, h *plugi
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			return nil, err
 		}

--- a/github/table_github_tag.go
+++ b/github/table_github_tag.go
@@ -65,7 +65,7 @@ func tableGitHubTagList(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 
 	for {
 
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 		if err != nil {
 			return nil, err
 		}

--- a/github/table_github_team.go
+++ b/github/table_github_team.go
@@ -92,7 +92,7 @@ func tableGitHubTeamList(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err
@@ -163,7 +163,7 @@ func tableGitHubTeamGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_team_member.go
+++ b/github/table_github_team_member.go
@@ -98,7 +98,7 @@ func tableGitHubTeamMemberList(ctx context.Context, d *plugin.QueryData, h *plug
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err
@@ -151,7 +151,7 @@ func tableGitHubTeamMemberGet(ctx context.Context, d *plugin.QueryData, h *plugi
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_team_repository.go
+++ b/github/table_github_team_repository.go
@@ -79,7 +79,7 @@ func tableGitHubTeamRepositoryList(ctx context.Context, d *plugin.QueryData, h *
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err
@@ -142,7 +142,7 @@ func tableGitHubTeamRepositoryGet(ctx context.Context, d *plugin.QueryData, h *p
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_traffic_view_daily.go
+++ b/github/table_github_traffic_view_daily.go
@@ -54,7 +54,7 @@ func tableGitHubTrafficViewDailyList(ctx context.Context, d *plugin.QueryData, h
 		}, err
 	}
 
-	listResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	listResponse, err := retryHydrate(ctx, d, h, listPage)
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_traffic_view_weekly.go
+++ b/github/table_github_traffic_view_weekly.go
@@ -53,7 +53,7 @@ func tableGitHubTrafficViewWeeklyList(ctx context.Context, d *plugin.QueryData, 
 			resp:         resp,
 		}, err
 	}
-	listResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	listResponse, err := retryHydrate(ctx, d, h, listPage)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_tree.go
+++ b/github/table_github_tree.go
@@ -73,7 +73,7 @@ func tableGitHubTreeList(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 			resp: resp,
 		}, err
 	}
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getTree, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getTree)
 
 	if err != nil {
 		logger.Error("github_tree.tableGitHubTreeList", "api_error", err)

--- a/github/table_github_user.go
+++ b/github/table_github_user.go
@@ -92,7 +92,7 @@ func tableGitHubUserGet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 			resp: resp,
 		}, err
 	}
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 
 	if err != nil {
 		return nil, err

--- a/github/table_github_workflow.go
+++ b/github/table_github_workflow.go
@@ -86,7 +86,7 @@ func tableGitHubWorkflowList(ctx context.Context, d *plugin.QueryData, h *plugin
 	}
 
 	for {
-		listPageResponse, err := plugin.RetryHydrate(ctx, d, h, listPage, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+		listPageResponse, err := retryHydrate(ctx, d, h, listPage)
 
 		if err != nil {
 			return nil, err
@@ -140,7 +140,7 @@ func tableGitHubWorkflowGet(ctx context.Context, d *plugin.QueryData, h *plugin.
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getDetails, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getDetails)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func GitHubWorkflowFileContent(ctx context.Context, d *plugin.QueryData, h *plug
 		}, err
 	}
 
-	getResponse, err := plugin.RetryHydrate(ctx, d, h, getFileContent, &plugin.RetryConfig{ShouldRetryError: shouldRetryError})
+	getResponse, err := retryHydrate(ctx, d, h, getFileContent)
 	if err != nil {
 		// the workflow object exists, but the file is deleted
 		if strings.Contains(err.Error(), "404 Not Found") {


### PR DESCRIPTION
The current retry logic often results in errors, I believe due to the following:
- Our current logic has a series of sleep times for retries of .5s, .5s, 1s, 1.5s, 2.5s, 2.5s, ..., 2.5s (10th attempt, always capped at 2.5s)
- GitHub's secondary rate limiting seems to come back with a minimum `RetryAfter` value of 1 second and a maximum of 1 minute
- So I believe we're not waiting not long enough initially and are trying too frequently after

This PR increases the initial wait time from .5s -> 1s, and now uses an exponential backoff, so the sleep times for retries now looks like 1s, 2s, 4s,  8s, 10s, 10s, ..., 10s (10th attempt, always capped at 10s).

From my initial tests, this has made larger queries sometimes take 2-3 minutes, but now all results appear more consistently.