### PR TITLE
Fix broken plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Install the plugin with [Steampipe](https://steampipe.io/downloads):
 
 ```shell
-steampipe plugin install github
+steampipe plugin install turbot/github
 ```
 
 [Configure the plugin](https://hub.steampipe.io/plugins/turbot/github#configuration) using the configuration file:


### PR DESCRIPTION
Plugin install fails because plugin name is incorrect