### PR TITLE
Add column `parent` to table `github_my_team` and `github_team`. Closes #231

### DIFF
--- a/docs/tables/github_my_team.md
+++ b/docs/tables/github_my_team.md
@@ -30,3 +30,17 @@ select
 from
   github_my_team;
 ```
+
+### Get parent team details for teams
+
+```sql
+select
+  slug,
+  organization,
+  parent ->> 'id' as parent_team_id,
+  parent ->> 'slug' as parent_team_slug
+from
+  github_my_team
+where
+  parent is not null;
+```

--- a/docs/tables/github_my_team.md
+++ b/docs/tables/github_my_team.md
@@ -31,7 +31,7 @@ from
   github_my_team;
 ```
 
-### Get parent team details for teams
+### Get parent team details for child teams
 
 ```sql
 select

--- a/docs/tables/github_team.md
+++ b/docs/tables/github_team.md
@@ -45,7 +45,7 @@ where
   slug = 'my_team';
 ```
 
-### Get parent team details for teams
+### Get parent team details for child teams
 
 ```sql
 select

--- a/docs/tables/github_team.md
+++ b/docs/tables/github_team.md
@@ -44,3 +44,17 @@ from
 where
   slug = 'my_team';
 ```
+
+### Get parent team details for teams
+
+```sql
+select
+  slug,
+  organization,
+  parent ->> 'id' as parent_team_id,
+  parent ->> 'slug' as parent_team_slug
+from
+  github_team
+where
+  parent is not null;
+```

--- a/github/table_github_team.go
+++ b/github/table_github_team.go
@@ -34,6 +34,7 @@ func gitHubTeamColumns() []*plugin.Column {
 		{Name: "organization_id", Type: proto.ColumnType_INT, Description: "The user id (number) of the organization.", Transform: transform.FromField("Organization.ID"), Hydrate: tableGitHubTeamGet},
 		{Name: "organization_login", Type: proto.ColumnType_STRING, Description: "The login name of the organization.", Transform: transform.FromField("Organization.Login"), Hydrate: tableGitHubTeamGet},
 		{Name: "organization_type", Type: proto.ColumnType_STRING, Description: "The type of the organization).", Transform: transform.FromField("Organization.Type"), Hydrate: tableGitHubTeamGet},
+		{Name: "parent", Type: proto.ColumnType_JSON, Description: "The parent team of the team."},
 		{Name: "permission", Type: proto.ColumnType_STRING, Description: "The default repository permissions of the team."},
 		{Name: "privacy", Type: proto.ColumnType_STRING, Description: "The privacy setting of the team (closed or secret)."},
 		{Name: "repos_count", Type: proto.ColumnType_INT, Description: "The number of repositories for the team.", Hydrate: tableGitHubTeamGet},


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  slug,
  organization,
  parent ->> 'id' as parent_team_id,
  parent ->> 'slug' as parent_team_slug
from
  github_team
where
  parent is not null;
+------------------+-----------------+----------------+------------------+
| slug             | organization    | parent_team_id | parent_team_slug |
+------------------+-----------------+----------------+------------------+
| compliance-admin | new-testing-org | 6380921        | test-team        |
| test-team3       | new-testing-org | 6381842        | compliance-admin |
+------------------+-----------------+----------------+------------------+
```
</details>
