### PR TITLE
fix: fixed repo search errors when hydrating v3 cols

### DIFF
--- a/github/models/search.go
+++ b/github/models/search.go
@@ -11,3 +11,10 @@ type TextMatchHighlight struct {
 	EndIndice   int    `json:"end_indice"`
 	Text        string `json:"text"`
 }
+
+type SearchRepositoryResult struct {
+	TextMatches []TextMatch
+	Node        struct {
+		Repository `graphql:"... on Repository"`
+	}
+}

--- a/github/table_github_search_repository.go
+++ b/github/table_github_search_repository.go
@@ -37,12 +37,7 @@ func tableGitHubSearchRepositoryList(ctx context.Context, d *plugin.QueryData, h
 		Search    struct {
 			RepositoryCount int
 			PageInfo        models.PageInfo
-			Edges           []struct {
-				TextMatches []models.TextMatch
-				Node        struct {
-					models.Repository `graphql:"... on Repository"`
-				}
-			}
+			Edges           []models.SearchRepositoryResult
 		} `graphql:"search(type: REPOSITORY, first: $pageSize, after: $cursor, query: $query)"`
 	}
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select topics from github.github_search_repository where query = 'repo:turbot/.github'
+--------+
| topics |
+--------+
| []     |
+--------+

> select topics from github.github_search_repository where query = 'repo:turbot/steampipe'
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| topics                                                                                                                                                                                            |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| ["aws","azure","cis","cloud","cnapp","cspm","cwpp","devops","devsecops","fdw","gcp","golang","hacktoberfest","kubernetes","postgresql","postgresql-fdw","security","sql","steampipe","terraform"] |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>
