### PR TITLE
fix: fixed github_team_repository table missing includes for dynamic gql

### DIFF
--- a/github/table_github_team_repository.go
+++ b/github/table_github_team_repository.go
@@ -70,6 +70,7 @@ func tableGitHubTeamRepositoryList(ctx context.Context, d *plugin.QueryData, h *
 		"pageSize": githubv4.Int(pageSize),
 		"cursor":   (*githubv4.String)(nil),
 	}
+	appendRepoColumnIncludes(&variables, d.QueryContext.Columns)
 
 	client := connectV4(ctx, d)
 	for {


### PR DESCRIPTION
# Before
<details>
  <summary>Results</summary>
  
```shell
steampipe query "select name_with_owner, created_at from github.github_team_repository where organization = 'turbot' and slug = 'steampipe'"
Error: Variable $includeAllowUpdateBranch is used by anonymous query but not declared (SQLSTATE HV000)

+-----------------+------------+
| name_with_owner | created_at |
+-----------------+------------+
+-----------------+------------+
```
</details>

# After
<details>
  <summary>Results</summary>
  
```
steampipe query "select name_with_owner, created_at from github.github_team_repository where organization = 'turbot' and slug = 'steampipe'"
+-------------------------------------------------+---------------------------+
| name_with_owner                                 | created_at                |
+-------------------------------------------------+---------------------------+
| turbot/steampipe                                | 2021-01-17T14:07:26Z      |
| turbot/steampipe-postgres-fdw                   | 2021-01-19T15:58:12Z      |
| turbot/steampipe-plugin-sdk                     | 2021-01-17T15:34:59Z      |
| turbot/steampipe-plugin-zendesk                 | 2021-01-20T12:59:25Z      |
| turbot/steampipe-mod-azure-compliance           | 2021-05-19T22:51:39+01:00 |
| turbot/steampipe-plugin-hackernews              | 2021-02-20T15:02:36Z      |
| turbot/steampipe-plugin-whois                   | 2021-01-20T20:51:53Z      |
| turbot/steampipe-plugin-urlscan                 | 2021-06-27T22:26:12+01:00 |
| turbot/steampipe-plugin-aws                     | 2021-01-17T15:43:52Z      |
| turbot/steampipe-plugin-docker                  | 2021-07-05T22:45:52+01:00 |
| turbot/steampipe-plugin-slack                   | 2021-01-20T12:56:34Z      |
| turbot/steampipe-plugin-chaos                   | 2021-01-21T12:41:34Z      |
| turbot/steampipe-mod-alicloud-compliance        | 2021-06-08T14:04:32+01:00 |
+-------------------------------------------------+---------------------------+

# abbreviated sample response
```
</details>
