### PR TITLE
Add github_repository_sbom table

### DIFF
--- a/docs/tables/github_repository_sbom.md
+++ b/docs/tables/github_repository_sbom.md
@@ -1,0 +1,20 @@
+# Table: github_repository_sbom
+
+The `github_repository_sbom` table can be used to query information about packages listed in the SBOM of a repository.
+
+**You must specify which repository** in the where or join clause using the `repository_full_name` column.
+
+## Examples
+
+### List SBOM packages
+
+```sql
+select
+  name,
+  version,
+  license
+from
+  github_repository_sbom
+where
+  repository_full_name = 'turbot/steampipe';
+```

--- a/docs/tables/github_repository_sbom.md
+++ b/docs/tables/github_repository_sbom.md
@@ -10,11 +10,13 @@ The `github_repository_sbom` table can be used to query information about packag
 
 ```sql
 select
-  name,
-  version,
-  license
+  github_repository_sbom,
+  p->>'name' as package_name,
+  p->>'versionInfo' as package_version,
+  p->>'licenseConcluded' as package_license
 from
-  github_repository_sbom
+  github_repository_sbom,
+  jsonb_array_elements(packages) p
 where
   repository_full_name = 'turbot/steampipe';
 ```

--- a/github/plugin.go
+++ b/github/plugin.go
@@ -54,6 +54,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"github_repository_dependabot_alert":     tableGitHubRepositoryDependabotAlert(),
 			"github_repository_deployment":           tableGitHubRepositoryDeployment(),
 			"github_repository_environment":          tableGitHubRepositoryEnvironment(),
+			"github_repository_sbom":          		  tableGitHubRepositorySbom(),
 			"github_repository_vulnerability_alert":  tableGitHubRepositoryVulnerabilityAlert(),
 			"github_search_code":                     tableGitHubSearchCode(),
 			"github_search_commit":                   tableGitHubSearchCommit(),

--- a/github/table_github_repository_sbom.go
+++ b/github/table_github_repository_sbom.go
@@ -30,24 +30,53 @@ func tableGitHubRepositorySbom() *plugin.Table {
 				Description: "The full name of the repository (login/repo-name).",
 			},
 			{
+				Name:        "spdx_id",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("SPDXID"),
+				Description: "The SPDX identifier for the SPDX document.",
+			},
+			{
+				Name:        "spdx_version",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("SPDXVersion"),
+				Description: "The version of the SPDX specification that this document conforms to.",
+			},
+			{
+				Name:        "creation_info",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("CreationInfo"),
+				Description: "The version of the SPDX specification that this document conforms to.",
+			},
+			{
 				Name:        "name",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("Name"),
-				Description: "The name of the package.",
+				Description: "The name of the SPDX document.",
 			},
 			{
-				Name:        "version",
+				Name:        "data_license",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("VersionInfo"),
-				Description: "Version info of the package.",
+				Transform:   transform.FromField("DataLicense"),
+				Description: "The license under which the SPDX document is licensed.",
 			},
 			{
-				Name:        "license",
+				Name:        "document_describes",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("LicenseConcluded"),
-				Description: "License of the package.",
+				Transform:   transform.FromField("DocumentDescribes"),
+				Description: "The name of the repository that the SPDX document describes.",
 			},
-			// TODO: there are more fields to be added here!
+			{
+				Name:        "document_namespace",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DocumentNamespace"),
+				Description: "The namespace for the SPDX document.",
+			},
+			{
+				Name:        "packages",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Packages"),
+				Description: "Array of packages in spdx format.",
+			},
 		},
 	}
 }
@@ -68,14 +97,7 @@ func tableGitHubRepositorySbomList(ctx context.Context, d *plugin.QueryData, h *
 		return nil, err
 	}
 
-	for _, i := range sbom.SBOM.Packages {
-		d.StreamListItem(ctx, i)
-
-		// Context can be cancelled due to manual cancellation or the limit has been hit
-		if d.RowsRemaining(ctx) == 0 {
-			return nil, nil
-		}
-	}
+	d.StreamListItem(ctx, sbom.SBOM)
 
 	return sbom, nil
 }

--- a/github/table_github_repository_sbom.go
+++ b/github/table_github_repository_sbom.go
@@ -1,0 +1,81 @@
+package github
+
+import (
+	"context"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func tableGitHubRepositorySbom() *plugin.Table {
+	return &plugin.Table{
+		Name:        "github_repository_sbom",
+		Description: "SBOM from a repository.",
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "repository_full_name",
+					Require: plugin.Required,
+				},
+			},
+			ShouldIgnoreError: isNotFoundError([]string{"404", "403"}),
+			Hydrate:           tableGitHubRepositorySbomList,
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "repository_full_name",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("repository_full_name"),
+				Description: "The full name of the repository (login/repo-name).",
+			},
+			{
+				Name:        "name",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+				Description: "The name of the package.",
+			},
+			{
+				Name:        "version",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("VersionInfo"),
+				Description: "Version info of the package.",
+			},
+			{
+				Name:        "license",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LicenseConcluded"),
+				Description: "License of the package.",
+			},
+			// TODO: there are more fields to be added here!
+		},
+	}
+}
+
+func tableGitHubRepositorySbomList(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var owner, repo string
+
+	logger := plugin.Logger(ctx)
+	quals := d.EqualsQuals
+
+	fullName := quals["repository_full_name"].GetStringValue()
+	owner, repo = parseRepoFullName(fullName)
+	logger.Trace("tableGitHubDependabotSbomGet", "owner", owner, "repo", repo)
+
+	client := connect(ctx, d)
+	sbom, _, err := client.DependencyGraph.GetSBOM(ctx, owner, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, i := range sbom.SBOM.Packages {
+		d.StreamListItem(ctx, i)
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
+	}
+
+	return sbom, nil
+}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```sql
> select              
  repository_full_name,
  p->>'name' as package_name,
  p->>'versionInfo' as package_version,
  p->>'licenseConcluded' as package_license
from
  github_repository_sbom,
  jsonb_array_elements(packages) p
where
  repository_full_name = 'turbot/steampipe'
limit 10;
+----------------------+-------------------------------------------+-----------------+-----------------+
| repository_full_name | package_name                              | package_version | package_license |
+----------------------+-------------------------------------------+-----------------+-----------------+
| turbot/steampipe     | com.github.turbot/steampipe               |                 | <null>          |
| turbot/steampipe     | npm:@actions/core                         | 1.2.6           | MIT             |
| turbot/steampipe     | npm:@actions/github                       | 4.0.0           | MIT             |
| turbot/steampipe     | npm:@actions/http-client                  | 1.0.9           | MIT             |
| turbot/steampipe     | npm:@octokit/auth-token                   | 2.4.3           | MIT             |
| turbot/steampipe     | npm:@octokit/core                         | 3.2.1           | MIT             |
| turbot/steampipe     | npm:@octokit/endpoint                     | 6.0.9           | MIT             |
| turbot/steampipe     | npm:@octokit/graphql                      | 4.5.7           | MIT             |
| turbot/steampipe     | npm:@octokit/plugin-paginate-rest         | 2.6.0           | MIT             |
| turbot/steampipe     | npm:@octokit/plugin-rest-endpoint-methods | 4.2.1           | MIT             |
```
</details>

First time contributor! I'm looking for / expecting feedback on:
1. ~Is this the right way to model the data since it is focusing on the packages and not top level SBOM metadata? I can see a possibility where it might be preferred to move this to a `github_repository_sbom_packages` table instead, but unsure if that is the right move or not.~ - Pivoted based on feedback!
2. ~Pending 2 - there are some fields missing, I wanted to get feedback before adding them!~ - Addressed!
