### PR TITLE
Added the run_started_at field to the workflow-run results

### DIFF
--- a/github/table_github_actions_repository_workflow_run.go
+++ b/github/table_github_actions_repository_workflow_run.go
@@ -58,6 +58,7 @@ func tableGitHubActionsRepositoryWorkflowRun() *plugin.Table {
 			{Name: "head_repository", Type: proto.ColumnType_JSON, Description: "The head repository info for the workflow run."},
 			{Name: "pull_requests", Type: proto.ColumnType_JSON, Description: "The pull request details for the workflow run."},
 			{Name: "repository", Type: proto.ColumnType_JSON, Description: "The repository info for the workflow run."},
+			{Name: "run_started_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("RunStartedAt").Transform(convertTimestamp), Description: "Time when the workflow run was started."},
 			{Name: "updated_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("UpdatedAt").Transform(convertTimestamp), Description: "Time when the workflow run was updated."},
 			{Name: "actor", Type: proto.ColumnType_JSON, Description: "The user whom initiated the first instance of this workflow run."},
 			{Name: "actor_login", Type: proto.ColumnType_STRING, Description: "The login of the user whom initiated the first instance of the workflow run.", Transform: transform.FromField("Actor.Login")},


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```sql
SELECT id
     , created_at
     , updated_at
  FROM github_actions_repository_workflow_run
 WHERE repository_full_name = 'stackla/stackla-node-short-url'
   AND event = 'workflow_dispatch'
   AND status = 'completed'
   AND conclusion = 'success'
```
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
