### PR TITLE
Fix get call of the github_team_repository table to add missing includes for dynamic gql

### DIFF
--- a/github/table_github_team_repository.go
+++ b/github/table_github_team_repository.go
@@ -2,9 +2,10 @@ package github
 
 import (
 	"context"
+	"strings"
+
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"strings"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
@@ -126,6 +127,7 @@ func tableGitHubTeamRepositoryGet(ctx context.Context, d *plugin.QueryData, h *p
 		"name":     githubv4.String(name),
 		"pageSize": githubv4.Int(1),
 	}
+	appendRepoColumnIncludes(&variables, d.QueryContext.Columns)
 
 	client := connectV4(ctx, d)
 	err := client.Query(ctx, &query, variables)


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from github_team_repository where organization = 'turbot' and slug = 'steampipe' and name = 'steampipe-plugin-urlscan'
+--------------+-----------+------------+-----------+----------------------------------+--------------------------+---------------------+-------------+--------------------+-----------------+----------------------->
| organization | slug      | permission | id        | node_id                          | name                     | allow_update_branch | archived_at | auto_merge_allowed | code_of_conduct | contact_links         >
+--------------+-----------+------------+-----------+----------------------------------+--------------------------+---------------------+-------------+--------------------+-----------------+----------------------->
| turbot       | steampipe | WRITE      | 380840770 | MDEwOlJlcG9zaXRvcnkzODA4NDA3NzA= | steampipe-plugin-urlscan | false               | <null>      | false              | <null>          | [{"about":"GitHub issu>
|              |           |            |           |                                  |                          |                     |             |                    |                 |                       >
+--------------+-----------+------------+-----------+----------------------------------+--------------------------+---------------------+-------------+--------------------+-----------------+----------------------->
```
</details>
