### PR TITLE
Add table github_repository_sbom

### DIFF
--- a/docs/tables/github_repository_sbom.md
+++ b/docs/tables/github_repository_sbom.md
@@ -1,0 +1,63 @@
+# Table: github_repository_sbom
+
+The `github_repository_sbom` table can be used to query information about packages listed in the SBOM of a repository.
+
+**You must specify which repository** in the where or join clause using the `repository_full_name` column.
+
+## Examples
+
+### List SBOM packages with a specific package version
+
+```sql
+select
+  spdx_id,
+  spdx_version,
+  p ->> 'name' as package_name,
+  p ->> 'versionInfo' as package_version,
+  p ->> 'licenseConcluded' as package_license
+from
+  github_repository_sbom,
+  jsonb_array_elements(packages) p
+where
+  p ->> 'versionInfo' = '2.6.0'
+  and repository_full_name = 'turbot/steampipe';
+```
+
+### Find SBOMs conforming to a specific SPDX version
+
+```sql
+select
+  name,
+  spdx_version
+from
+  github_repository_sbom
+where
+  spdx_version = '2.2'
+  and repository_full_name = 'turbot/steampipe';
+```
+
+### Retrieve SBOMs under a specific data license
+
+```sql
+select
+  name,
+  data_license
+from
+  github_repository_sbom
+where
+  data_license = 'CC0-1.0'
+  and repository_full_name = 'turbot/steampipe';
+```
+
+### Find SBOMs created by a specific user or at a specific time
+
+```sql
+select
+  repository_full_name,
+  creation_info
+from
+  github_repository_sbom
+where
+  (creation_info ->> 'created_by' = 'madhushreeray30' or creation_info ->> 'created_at' = '2023-11-16')
+  and repository_full_name = 'turbot/steampipe';
+```

--- a/github/plugin.go
+++ b/github/plugin.go
@@ -54,6 +54,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"github_repository_dependabot_alert":     tableGitHubRepositoryDependabotAlert(),
 			"github_repository_deployment":           tableGitHubRepositoryDeployment(),
 			"github_repository_environment":          tableGitHubRepositoryEnvironment(),
+			"github_repository_sbom":                 tableGitHubRepositorySbom(),
 			"github_repository_vulnerability_alert":  tableGitHubRepositoryVulnerabilityAlert(),
 			"github_search_code":                     tableGitHubSearchCode(),
 			"github_search_commit":                   tableGitHubSearchCommit(),

--- a/github/table_github_repository_sbom.go
+++ b/github/table_github_repository_sbom.go
@@ -1,0 +1,103 @@
+package github
+
+import (
+	"context"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func tableGitHubRepositorySbom() *plugin.Table {
+	return &plugin.Table{
+		Name:        "github_repository_sbom",
+		Description: "Get the software bill of materials (SBOM) for a repository.",
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "repository_full_name",
+					Require: plugin.Required,
+				},
+			},
+			ShouldIgnoreError: isNotFoundError([]string{"404", "403"}),
+			Hydrate:           tableGitHubRepositorySbomList,
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "repository_full_name",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("repository_full_name"),
+				Description: "The full name of the repository (login/repo-name).",
+			},
+			{
+				Name:        "spdx_id",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("SPDXID"),
+				Description: "The SPDX identifier for the SPDX document.",
+			},
+			{
+				Name:        "spdx_version",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("SPDXVersion"),
+				Description: "The version of the SPDX specification that this document conforms to.",
+			},
+			{
+				Name:        "creation_info",
+				Type:        proto.ColumnType_JSON,
+				// Transform:   transform.FromField("CreationInfo"),
+				Description: "It represents when the SBOM was created and who created it.",
+			},
+			{
+				Name:        "name",
+				Type:        proto.ColumnType_STRING,
+				// Transform:   transform.FromField("Name"),
+				Description: "The name of the SPDX document.",
+			},
+			{
+				Name:        "data_license",
+				Type:        proto.ColumnType_STRING,
+				// Transform:   transform.FromField("DataLicense"),
+				Description: "The license under which the SPDX document is licensed.",
+			},
+			{
+				Name:        "document_describes",
+				Type:        proto.ColumnType_JSON,
+				// Transform:   transform.FromField("DocumentDescribes"),
+				Description: "The name of the repository that the SPDX document describes.",
+			},
+			{
+				Name:        "document_namespace",
+				Type:        proto.ColumnType_STRING,
+				// Transform:   transform.FromField("DocumentNamespace"),
+				Description: "The namespace for the SPDX document.",
+			},
+			{
+				Name:        "packages",
+				Type:        proto.ColumnType_JSON,
+				// Transform:   transform.FromField("Packages"),
+				Description: "Array of packages in SPDX format.",
+			},
+		},
+	}
+}
+
+func tableGitHubRepositorySbomList(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var owner, repo string
+
+	logger := plugin.Logger(ctx)
+	quals := d.EqualsQuals
+
+	fullName := quals["repository_full_name"].GetStringValue()
+	owner, repo = parseRepoFullName(fullName)
+	logger.Trace("tableGitHubDependabotSbomGet", "owner", owner, "repo", repo)
+
+	client := connect(ctx, d)
+	sbom, _, err := client.DependencyGraph.GetSBOM(ctx, owner, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	d.StreamListItem(ctx, sbom.SBOM)
+
+	return sbom, nil
+}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select spdx_id, spdx_version, name, data_license, creation_info from github_repository_sbom where repository_full_name = 'turbot/steampipe'
[
 {
  "creation_info": {
   "created": "2023-11-17T12:02:00Z",
   "creators": [
    "Tool: GitHub.com-Dependency-Graph"
   ]
  },
  "data_license": "CC0-1.0",
  "name": "com.github.turbot/steampipe",
  "spdx_id": "SPDXRef-DOCUMENT",
  "spdx_version": "SPDX-2.3"
 }
]

```
</details>
