### PR TITLE
revise labels query

### DIFF
--- a/docs/tables/github_issue.md
+++ b/docs/tables/github_issue.md
@@ -172,14 +172,21 @@ select
   repository_full_name,
   number,
   title,
-  json_group_array(t.value) as labels
+  (
+    select json_group_array(label)
+    from (
+      select json_each.key as label
+      from json_each(i.labels)
+    )
+  ) as labels
 from
-  github_issue i,
-  json_each(i.labels) as t
+  github_issue i
 where
   repository_full_name = 'turbot/steampipe'
 group by
-  repository_full_name, number, title;
+  repository_full_name,
+  number,
+  title;
 ```
 
 OR


### PR DESCRIPTION
the original query fails because the labels we want are keys not values

```
select
  repository_full_name,
  number,
  title,
  json_group_array(t.value) as labels
from
  github_issue i,
  json_each(i.labels) as t
where
  repository_full_name = 'turbot/steampipe'
group by
  repository_full_name,
  number,
  title;
```

output is like:

turbot/steampipe|4039|query cancellation leads to nil pointer exception|[1]

this succeeds

```
select
  repository_full_name,
  number,
  title,
  (
    select json_group_array(label)
    from (
      select json_each.key as label
      from json_each(i.labels)
    )
  ) as labels
from
  github_issue i
where
  repository_full_name = 'turbot/steampipe'
group by
  repository_full_name,
  number,
  title;
```

output is like:

turbot/steampipe|4039|query cancellation leads to nil pointer exception|["bug"]

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
