### PR TITLE
Refine error message for 'github_workflow' table during file parsing. Closes #436

### DIFF
--- a/github/table_github_workflow.go
+++ b/github/table_github_workflow.go
@@ -179,7 +179,7 @@ func decodeFileContentToPipeline(ctx context.Context, d *transform.TransformData
 	pipeline, err := goPipeline.Parse(strings.NewReader(contentDetails.Content))
 	if err != nil {
 		plugin.Logger(ctx).Error("github_workflow.decodeFileContentToPipeline", "Pipeline conversion error", err)
-		return nil, fmt.Errorf("failed to parse the workflow file '%s'", contentDetails.FilePath)
+		return nil, fmt.Errorf("failed to parse the workflow file '%s', %v", contentDetails.FilePath, err)
 	}
 
 	return pipeline, nil
@@ -197,7 +197,7 @@ func unmarshalYAML(_ context.Context, d *transform.TransformData) (interface{}, 
 	if inputStr != "" {
 		err := yaml.Unmarshal([]byte(inputStr), &result)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert YAML to JSON in file '%s'", contentDetails.FilePath)
+			return nil, fmt.Errorf("failed to convert YAML to JSON in file '%s', %v", contentDetails.FilePath, err)
 		}
 	}
 

--- a/github/table_github_workflow.go
+++ b/github/table_github_workflow.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"strings"
 
 	goPipeline "github.com/buildkite/go-pipeline"
@@ -44,11 +45,17 @@ func tableGitHubWorkflow() *plugin.Table {
 			{Name: "state", Type: proto.ColumnType_STRING, Description: "State of the workflow."},
 			{Name: "updated_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("UpdatedAt").Transform(convertTimestamp), Description: "Time when the workflow was updated."},
 			{Name: "url", Type: proto.ColumnType_STRING, Description: "URL of the workflow."},
-			{Name: "workflow_file_content", Type: proto.ColumnType_STRING, Hydrate: GitHubWorkflowFileContent, Transform: transform.FromValue().Transform(decodeFileContentBase64), Description: "Content of github workflow file in text format."},
-			{Name: "workflow_file_content_json", Type: proto.ColumnType_JSON, Hydrate: GitHubWorkflowFileContent, Transform: transform.FromValue().Transform(decodeFileContentBase64).Transform(unmarshalYAML), Description: "Content of github workflow file in the JSON format."},
-			{Name: "pipeline", Type: proto.ColumnType_JSON, Hydrate: GitHubWorkflowFileContent, Transform: transform.FromValue().Transform(decodeFileContentBase64).Transform(decodeFileContentToPipeline), Description: "Github workflow in the generic pipeline entity format to be used across CI/CD platforms."},
+			{Name: "workflow_file_content", Type: proto.ColumnType_STRING, Hydrate: GitHubWorkflowFileContent, Transform: transform.FromValue().TransformP(decodeFileContentBase64, "workflow_file_content"), Description: "Content of github workflow file in text format."},
+			{Name: "workflow_file_content_json", Type: proto.ColumnType_JSON, Hydrate: GitHubWorkflowFileContent, Transform: transform.FromValue().TransformP(decodeFileContentBase64, "workflow_file_content_json").Transform(unmarshalYAML), Description: "Content of github workflow file in the JSON format."},
+			{Name: "pipeline", Type: proto.ColumnType_JSON, Hydrate: GitHubWorkflowFileContent, Transform: transform.FromValue().TransformP(decodeFileContentBase64, "pipeline").Transform(decodeFileContentToPipeline), Description: "Github workflow in the generic pipeline entity format to be used across CI/CD platforms."},
 		}),
 	}
+}
+
+type FileContent struct {
+	Repository string
+	FilePath   string
+	Content    string
 }
 
 func tableGitHubWorkflowList(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -155,20 +162,24 @@ func decodeFileContentBase64(ctx context.Context, d *transform.TransformData) (i
 		return nil, err
 	}
 
-	return string(decodedText), nil
+	if d.Param.(string) == "workflow_file_content" {
+		return string(decodedText), nil
+	}
+
+	return FileContent{*repContent.Name, *repContent.HTMLURL, string(decodedText)}, nil
 }
 
 // decodeFileContentToPipeline:: Converts the workflow decoded text to generic CI pipeline.
 func decodeFileContentToPipeline(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	repContent, ok := d.Value.(string)
+	contentDetails, ok := d.Value.(FileContent)
 	if !ok {
 		return nil, nil
 	}
 
-	pipeline, err := goPipeline.Parse(strings.NewReader(repContent))
+	pipeline, err := goPipeline.Parse(strings.NewReader(contentDetails.Content))
 	if err != nil {
 		plugin.Logger(ctx).Error("github_workflow.decodeFileContentToPipeline", "Pipeline conversion error", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to parse the workflow file '%s'", contentDetails.FilePath)
 	}
 
 	return pipeline, nil
@@ -179,12 +190,14 @@ func unmarshalYAML(_ context.Context, d *transform.TransformData) (interface{}, 
 	if d.Value == nil {
 		return nil, nil
 	}
-	inputStr := types.SafeString(d.Value)
+	contentDetails := d.Value.(FileContent)
+
+	inputStr := types.SafeString(contentDetails.Content)
 	var result interface{}
 	if inputStr != "" {
 		err := yaml.Unmarshal([]byte(inputStr), &result)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to convert YAML to JSON in file '%s'", contentDetails.FilePath)
 		}
 	}
 


### PR DESCRIPTION


# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, path, workflow_file_content, workflow_file_content_json, pipeline from github_workflow where repository_full_name = 'turbot/steampipe-plugin-aws'
+---------------------------------------+---------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------->
| name                                  | path                                        | workflow_file_content                                                                                                              | workflow_file_content_json                      >
+---------------------------------------+---------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------->
| Stale Issues and PRs                  | .github/workflows/stale.yml                 | name: Stale Issues and PRs                                                                                                         | {"jobs":{"stale_workflow":{"uses":"turbot/steamp>
|                                       |                                             | on:                                                                                                                                |                                                 >
|                                       |                                             |   schedule:                                                                                                                        |                                                 >
|                                       |                                             |     - cron: "30 23 * * *"                                                                                                          |                                                 >
|                                       |                                             |   workflow_dispatch:                                                                                                               |                                                 >
|                                       |                                             |     inputs:                                                                                                                        |                                                 >
|                                       |                                             |       dryRun:                                                                                                                      |                                                 >
|                                       |                                             |         description: Set to true for a dry run                                                                                     |                                                 >
|                                       |                                             |         required: false                                                                                                            |                                                 >
|                                       |                                             |         default: "false"                                                                                                           |                                                 >
|                                       |                                             |         type: string                                                                                                               |                                                 >
|                                       |                                             |                                                                                                                                    |                                                 >
|                                       |                                             | jobs:                                                                                                                              |                                                 >
|                                       |                                             |   stale_workflow:                                                                                                                  |                                                 >
|                                       |                                             |     uses: turbot/steampipe-workflows/.github/workflows/stale.yml@main                                                              |                                                 >
|                                       |                                             |     with:                                                                                                                          |                                                 >
|                                       |                                             |       dryRun: ${{ github.event.inputs.dryRun }}                                                                                    |                                                 >
|                                       |                                             |                                                                                                                                    |                                                 >
| CodeQL                                | dynamic/github-code-scanning/codeql         | <null>                                                                                                                             | <null>                                          >
| Build and Deploy OCI Image            | .github/workflows/registry-publish.yml      | name: Build and Deploy OCI Image                                                                                                   | {"env":{"CONFIG_SCHEMA_VERSION":"2020-11-18","OR>
|                                       |                                             |                                                                                                                                    | nvalid version: $VERSION\"\n  exit 1\nfi"},{"nam>
|                                       |                                             | on:                                                                                                                                | pipe-plugin-${{ env.PLUGIN_NAME }}_linux_arm64.g>
|                                       |                                             |   push:                                                                                                                            | TRY_SA_KEY }}"}},{"run":"gcloud config list"},{">
|                                       |                                             |     tags:                                                                                                                          | o \"VERSION=${GITHUB_REF#refs/*/}\" \u003e\u003e>

Improved the error message: 

> select name, path, workflow_file_content, workflow_file_content_json from github_workflow where repository_full_name = 'pro-cloud-49/test37'

Error: github: failed to populate column 'pipeline': failed to parse the workflow file 'https://github.com/pro-cloud-49/test37/blob/main/.github/workflows/test.yaml' (SQLSTATE HV000)

+------+------+-----------------------+----------------------------+
| name | path | workflow_file_content | workflow_file_content_json |
+------+------+-----------------------+----------------------------+
+------+------+-----------------------+----------------------------+
```
</details>
