### PR TITLE
Add `run_attempt` as an optional key column for `github_actions_repository_workflow_run` get calls

### DIFF
--- a/github/table_github_actions_repository_workflow_run.go
+++ b/github/table_github_actions_repository_workflow_run.go
@@ -8,6 +8,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v5/query_cache"
 )
 
 func tableGitHubActionsRepositoryWorkflowRun() *plugin.Table {
@@ -26,7 +27,11 @@ func tableGitHubActionsRepositoryWorkflowRun() *plugin.Table {
 			},
 		},
 		Get: &plugin.GetConfig{
-			KeyColumns:        plugin.AllColumns([]string{"repository_full_name", "id"}),
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "repository_full_name", Require: plugin.Required, Operators: []string{"="}},
+				{Name: "id", Require: plugin.Required, Operators: []string{"="}},
+				{Name: "run_attempt", Require: plugin.Optional, Operators: []string{"="}, CacheMatch: query_cache.CacheMatchExact},
+			},
 			ShouldIgnoreError: isNotFoundError([]string{"404"}),
 			Hydrate:           tableGitHubRepoWorkflowRunGet,
 		},
@@ -141,6 +146,7 @@ func tableGitHubRepoWorkflowRunList(ctx context.Context, d *plugin.QueryData, h 
 
 func tableGitHubRepoWorkflowRunGet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	runId := d.EqualsQuals["id"].GetInt64Value()
+	runAttempt := int(d.EqualsQuals["run_attempt"].GetInt64Value())
 	orgName := d.EqualsQuals["repository_full_name"].GetStringValue()
 
 	// Empty check for the parameters
@@ -149,11 +155,20 @@ func tableGitHubRepoWorkflowRunGet(ctx context.Context, d *plugin.QueryData, h *
 	}
 
 	owner, repo := parseRepoFullName(orgName)
-	plugin.Logger(ctx).Trace("tableGitHubRepoWorkflowRunGet", "owner", owner, "repo", repo, "runId", runId)
+	plugin.Logger(ctx).Trace("tableGitHubRepoWorkflowRunGet", "owner", owner, "repo", repo, "runId", runId, "runAttempt", runAttempt)
 
 	client := connect(ctx, d)
 
-	workflowRun, _, err := client.Actions.GetWorkflowRunByID(ctx, owner, repo, runId)
+	var (
+		workflowRun *github.WorkflowRun
+		err         error
+	)
+	if runAttempt != 0 {
+		opts := &github.WorkflowRunAttemptOptions{}
+		workflowRun, _, err = client.Actions.GetWorkflowRunAttempt(ctx, owner, repo, runId, runAttempt, opts)
+	} else {
+		workflowRun, _, err = client.Actions.GetWorkflowRunByID(ctx, owner, repo, runId)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/github/table_github_actions_repository_workflow_run.go
+++ b/github/table_github_actions_repository_workflow_run.go
@@ -49,6 +49,7 @@ func tableGitHubActionsRepositoryWorkflowRun() *plugin.Table {
 			{Name: "jobs_url", Type: proto.ColumnType_STRING, Description: "The address for the workflow job GitHub web page."},
 			{Name: "logs_url", Type: proto.ColumnType_STRING, Description: "The address for the workflow logs GitHub web page."},
 			{Name: "rerun_url", Type: proto.ColumnType_STRING, Description: "The address for workflow rerun GitHub web page."},
+			{Name: "previous_attempt_url", Type: proto.ColumnType_STRING, Description: "The address for the previous attempt GitHub web page."},
 			{Name: "url", Type: proto.ColumnType_STRING, Description: "The address for the workflow run GitHub web page.", Transform: transform.FromField("URL")},
 			{Name: "workflow_url", Type: proto.ColumnType_STRING, Description: "The address for workflow GitHub web page."},
 
@@ -58,6 +59,7 @@ func tableGitHubActionsRepositoryWorkflowRun() *plugin.Table {
 			{Name: "head_repository", Type: proto.ColumnType_JSON, Description: "The head repository info for the workflow run."},
 			{Name: "pull_requests", Type: proto.ColumnType_JSON, Description: "The pull request details for the workflow run."},
 			{Name: "repository", Type: proto.ColumnType_JSON, Description: "The repository info for the workflow run."},
+			{Name: "run_attempt", Type: proto.ColumnType_INT, Description: "The attempt number of the workflow run."},
 			{Name: "run_started_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("RunStartedAt").Transform(convertTimestamp), Description: "Time when the workflow run was started."},
 			{Name: "updated_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("UpdatedAt").Transform(convertTimestamp), Description: "Time when the workflow run was updated."},
 			{Name: "actor", Type: proto.ColumnType_JSON, Description: "The user whom initiated the first instance of this workflow run."},


### PR DESCRIPTION
_builds upon #463, but that PR can be considered separately from this one_

This is the bare minimum to allow previous run attempts to be queried, which is useful for comparisons between attempts. User queries must explicitly iterate over a run's multiple attempts as necessary, e.g. by parsing `previous_attempt_url` in a `with recursive` CTE or simply presuming the series of attempts is `generate_series(1, run_attempt)`.

A future improvement for this plugin might be exposing a new table, e.g. `github_actions_repository_workflow_run_attempt`, with the same list key columns of `repository_full_name` and `id`, and handling the iteration internally. GitHub's API unfortunately provides no listing endpoints for run attempts.
