### PR TITLE
Update GraphQL schema for github_organization table and remove `projects_total_count` column as per deprecation notice Closes #487

### DIFF
--- a/github/models/organization.go
+++ b/github/models/organization.go
@@ -16,9 +16,7 @@ type BasicOrganization struct {
 
 type Organization struct {
 	BasicOrganization
-	Announcement                           string                       `graphql:"announcement @include(if:$includeAnnouncement)" json:"announcement"`
-	AnnouncementExpiresAt                  NullableTime                 `graphql:"announcementExpiresAt @include(if:$includeAnnouncementExpiresAt)" json:"announcement_expires_at"`
-	AnnouncementUserDismissible            bool                         `graphql:"announcementUserDismissible @include(if:$includeAnnouncementUserDismissible)" json:"announcement_user_dismissible"`
+	AnnouncementBanner                     AnnouncementBannerInfo       `graphql:"announcementBanner @include(if:$includeAnnouncementBanner)" json:"announcement_banner"`
 	AnyPinnableItems                       bool                         `graphql:"anyPinnableItems @include(if:$includeAnyPinnableItems)" json:"any_pinnable_items"`
 	AvatarUrl                              string                       `graphql:"avatarUrl @include(if:$includeAvatarUrl)" json:"avatar_url"`
 	EstimatedNextSponsorsPayoutInCents     int                          `graphql:"estimatedNextSponsorsPayoutInCents @include(if:$includeEstimatedNextSponsorsPayoutInCents)" json:"estimated_next_sponsors_payout_in_cents"`
@@ -84,13 +82,19 @@ type OrganizationWithOwnerProperties struct {
 	WebCommitSignoffRequired                      bool                                                    `json:"web_commit_signoff_required"`
 }
 
+type AnnouncementBannerInfo struct {
+	Message           string       `json:"message"`
+	CreatedAt         NullableTime `json:"created_at"`
+	ExpiresAt         NullableTime `json:"expires_at"`
+	IsUserDismissible bool         `json:"is_user_dismissible"`
+}
+
 type OrganizationWithCounts struct {
 	Organization
 	MembersWithRole     Count `graphql:"membersWithRole @include(if:$includeMembersWithRole)" json:"members_with_role"`
 	Packages            Count `graphql:"packages @include(if:$includePackages)" json:"packages"`
 	PinnableItems       Count `graphql:"pinnableItems @include(if:$includePinnableItems)" json:"pinnable_items"`
 	PinnedItems         Count `graphql:"pinnedItems @include(if:$includePinnedItems)" json:"pinned_items"`
-	Projects            Count `graphql:"projects @include(if:$includeProjects)" json:"projects"`
 	ProjectsV2          Count `graphql:"projectsV2 @include(if:$includeProjectsV2)" json:"projects_v2"`
 	Sponsoring          Count `graphql:"sponsoring @include(if:$includeSponsoring)" json:"sponsoring"`
 	Sponsors            Count `graphql:"sponsors @include(if:$includeSponsors)" json:"sponsors"`

--- a/github/organization_utils.go
+++ b/github/organization_utils.go
@@ -120,9 +120,7 @@ func extractOrgCollaboratorFromHydrateItem(h *plugin.HydrateData) (OrgCollaborat
 }
 
 func appendOrganizationColumnIncludes(m *map[string]interface{}, cols []string) {
-	(*m)["includeAnnouncement"] = githubv4.Boolean(slices.Contains(cols, "announcement"))
-	(*m)["includeAnnouncementExpiresAt"] = githubv4.Boolean(slices.Contains(cols, "announcement_expires_at"))
-	(*m)["includeAnnouncementUserDismissible"] = githubv4.Boolean(slices.Contains(cols, "announcement_user_dismissible"))
+	(*m)["includeAnnouncementBanner"] = githubv4.Boolean(slices.Contains(cols, "announcement") || slices.Contains(cols, "announcement_expires_at") || slices.Contains(cols, "announcement_user_dismissible"))
 	(*m)["includeAnyPinnableItems"] = githubv4.Boolean(slices.Contains(cols, "any_pinnable_items"))
 	(*m)["includeAvatarUrl"] = githubv4.Boolean(slices.Contains(cols, "avatar_url"))
 	(*m)["includeEstimatedNextSponsorsPayoutInCents"] = githubv4.Boolean(slices.Contains(cols, "estimated_next_sponsors_payout_in_cents"))
@@ -149,7 +147,6 @@ func appendOrganizationColumnIncludes(m *map[string]interface{}, cols []string) 
 	(*m)["includePackages"] = githubv4.Boolean(slices.Contains(cols, "packages_total_count"))
 	(*m)["includePinnableItems"] = githubv4.Boolean(slices.Contains(cols, "pinnable_items_total_count"))
 	(*m)["includePinnedItems"] = githubv4.Boolean(slices.Contains(cols, "pinned_items_total_count"))
-	(*m)["includeProjects"] = githubv4.Boolean(slices.Contains(cols, "projects_total_count"))
 	(*m)["includeProjectsV2"] = githubv4.Boolean(slices.Contains(cols, "projects_v2_total_count"))
 	(*m)["includeSponsoring"] = githubv4.Boolean(slices.Contains(cols, "sponsoring_total_count"))
 	(*m)["includeSponsors"] = githubv4.Boolean(slices.Contains(cols, "sponsors_total_count"))
@@ -191,15 +188,6 @@ func orgHydratePinnedItemsTotalCount(_ context.Context, _ *plugin.QueryData, h *
 	}
 	return org.PinnedItems.TotalCount, nil
 }
-
-func orgHydrateProjectsTotalCount(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	org, err := extractOrganizationFromHydrateItem(h)
-	if err != nil {
-		return nil, err
-	}
-	return org.Projects.TotalCount, nil
-}
-
 func orgHydrateProjectsV2TotalCount(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	org, err := extractOrganizationFromHydrateItem(h)
 	if err != nil {
@@ -269,7 +257,7 @@ func orgHydrateAnnouncement(_ context.Context, _ *plugin.QueryData, h *plugin.Hy
 	if err != nil {
 		return nil, err
 	}
-	return org.Announcement, nil
+	return org.AnnouncementBanner.Message, nil
 }
 
 func orgHydrateAnnouncementExpiresAt(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -277,7 +265,7 @@ func orgHydrateAnnouncementExpiresAt(_ context.Context, _ *plugin.QueryData, h *
 	if err != nil {
 		return nil, err
 	}
-	return org.AnnouncementExpiresAt, nil
+	return org.AnnouncementBanner.ExpiresAt, nil
 }
 
 func orgHydrateAnnouncementUserDismissible(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -285,7 +273,7 @@ func orgHydrateAnnouncementUserDismissible(_ context.Context, _ *plugin.QueryDat
 	if err != nil {
 		return nil, err
 	}
-	return org.AnnouncementUserDismissible, nil
+	return org.AnnouncementBanner.IsUserDismissible, nil
 }
 
 func orgHydrateAnyPinnableItems(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/github/table_github_organization.go
+++ b/github/table_github_organization.go
@@ -86,7 +86,6 @@ func sharedOrganizationCountColumns() []*plugin.Column {
 		{Name: "packages_total_count", Type: proto.ColumnType_INT, Hydrate: orgHydratePackagesTotalCount, Transform: transform.FromValue(), Description: "Count of packages within the organization."},
 		{Name: "pinnable_items_total_count", Type: proto.ColumnType_INT, Hydrate: orgHydratePinnableItemsTotalCount, Transform: transform.FromValue(), Description: "Count of pinnable items within the organization."},
 		{Name: "pinned_items_total_count", Type: proto.ColumnType_INT, Hydrate: orgHydratePinnedItemsTotalCount, Transform: transform.FromValue(), Description: "Count of itesm pinned to the organization's profile."},
-		{Name: "projects_total_count", Type: proto.ColumnType_INT, Hydrate: orgHydrateProjectsTotalCount, Transform: transform.FromValue(), Description: "Count of projects within the organization."},
 		{Name: "projects_v2_total_count", Type: proto.ColumnType_INT, Hydrate: orgHydrateProjectsV2TotalCount, Transform: transform.FromValue(), Description: "Count of V2 projects within the organization."},
 		{Name: "repositories_total_count", Type: proto.ColumnType_INT, Hydrate: orgHydrateRepositoriesTotalCount, Transform: transform.FromValue(), Description: "Count of all repositories within the organization."},
 		{Name: "sponsoring_total_count", Type: proto.ColumnType_INT, Hydrate: orgHydrateSponsoringTotalCount, Transform: transform.FromValue(), Description: "Count of users the organization is sponsoring."},


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from github_organization where login = 'turbot'
+----------------------+--------+----------+----------------------------------+--------+---------------------------+---------------------------+--------------------------+--------------------+---------------------------+--------------+-------------------------+-------->
| login_id             | login  | id       | node_id                          | name   | created_at                | updated_at                | description              | email              | url                       | announcement | announcement_expires_at | announc>
+----------------------+--------+----------+----------------------------------+--------+---------------------------+---------------------------+--------------------------+--------------------+---------------------------+--------------+-------------------------+-------->
| MHS7dFNlcjQ3ODg32384 | turbot | 98268274 | MDEyOk9yZ2FuaXphddsaienalJJDJSLA | Turbot | 2018-04-30T23:25:30+05:30 | 2025-03-10T17:44:11+05:30 | Conquer cloud complexity | support@turbot.com | https://github.com/turbot |              | <null>                  | false  >
+----------------------+--------+----------+----------------------------------+--------+---------------------------+---------------------------+--------------------------+--------------------+---------------------------+--------------+-------------------------+-------->

Time: 2.5s. Rows returned: 0. Rows fetched: 1. Hydrate calls: 45.

Scans:
  1) github_organization.github: Time: 2.4s. Fetched: 1. Hydrates: 45. Quals: login=turbot.
```
</details>
