### PR TITLE
Add support for fine grained acces token

### DIFF
--- a/config/github.spc
+++ b/config/github.spc
@@ -6,6 +6,8 @@ connection "github" {
   #   https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token for more information.
   # - GitHub application installation access token, e.g., `ghs_UdmjfiKzVbFJNBsaiePwFPCmKeFakeToken`
   #   https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app for more information.
+  # - Fine-grained personal access token, e.g., `github_pat_11AKSHEQA0VptbjTZnO4at_lgZnoGwpuXb1noakeOG337zfnDQYIB5iJSUkUlMt8nH6KPO3NFakeToken`
+  #   https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token for more information.
   # Can also be set with the GITHUB_TOKEN environment variable.
   # token = "ghp_3b99b12218f63bcd702ad90d345975ef6c62f7d8"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,8 @@ connection "github" {
   #   https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token for more information.
   # - GitHub application installation access token, e.g., `ghs_UdmjfiKzVbFJNBsaiePwFPCmKeFakeToken`
   #   https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-an-installation-access-token-for-an-app for more information.
+  # - Fine-grained personal access token, e.g., `github_pat_11AKSHEQA0VptbjTZnO4at_lgZnoGwpuXb1noakeOG337zfnDQYIB5iJSUkUlMt8nH6KPO3NFakeToken`
+  #   https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token for more information.
   # Can also be set with the GITHUB_TOKEN environment variable.
   # token = "ghp_3b99b12218f63bcd702ad90d345975ef6c62f7d8"
 

--- a/github/models/misc.go
+++ b/github/models/misc.go
@@ -45,7 +45,7 @@ type Language struct {
 }
 
 type SponsorsListing struct {
-	Id                         string               `json:"id"`
+	Id                         string               `json:"id,omitempty"`
 	ActiveGoal                 SponsorsGoal         `json:"active_goal"`
 	ActiveStripeConnectAccount StripeConnectAccount `json:"active_stripe_connect_account"`
 	BillingCountryOrRegion     string               `json:"billing_country_or_region"`

--- a/github/models/repository.go
+++ b/github/models/repository.go
@@ -23,7 +23,7 @@ type Repository struct {
 	HasVulnerabilityAlertsEnabled bool                             `graphql:"hasVulnerabilityAlertsEnabled @include(if:$includeHasVulnerabilityAlertsEnabled)" json:"has_vulnerability_alerts_enabled"`
 	HasWikiEnabled                bool                             `graphql:"hasWikiEnabled @include(if:$includeHasWikiEnabled)" json:"has_wiki_enabled"`
 	HomepageUrl                   string                           `graphql:"homepageUrl @include(if:$includeHomepageUrl)" json:"homepage_url"`
-	InteractionAbility            RepositoryInteractionAbility     `graphql:"interactionAbility @include(if:$includeInteractionAbility)" json:"interaction_ability"`
+	InteractionAbility            RepositoryInteractionAbility     `graphql:"interactionAbility @include(if:$includeUserInteractionAbility)" json:"interaction_ability,omitempty"`
 	IsArchived                    bool                             `graphql:"isArchived @include(if:$includeIsArchived)" json:"is_archived"`
 	IsBlankIssuesEnabled          bool                             `graphql:"isBlankIssuesEnabled @include(if:$includeIsBlankIssuesEnabled)" json:"is_blank_issues_enabled"`
 	IsDisabled                    bool                             `graphql:"isDisabled @include(if:$includeIsDisabled)" json:"is_disabled"`

--- a/github/models/user.go
+++ b/github/models/user.go
@@ -10,7 +10,7 @@ type basicIdentifiers struct {
 type BasicUser struct {
 	basicIdentifiers
 	Login     string       `json:"login"`
-	Email     string       `json:"email"`
+	Email     string       `json:"email,omitempty"`
 	CreatedAt NullableTime `json:"created_at"`
 	UpdatedAt NullableTime `json:"updated_at"`
 	Url       string       `json:"url"`
@@ -43,7 +43,7 @@ type User struct {
 	IsSiteAdmin                           bool                         `graphql:"isSiteAdmin @include(if:$includeUserIsSiteAdmin)" json:"is_site_admin"`
 	IsSponsoringYou                       bool                         `graphql:"isSponsoringYou: isSponsoringViewer @include(if:$includeUserIsSponsoringYou)" json:"is_sponsoring_you"`
 	IsYou                                 bool                         `graphql:"isYou: isViewer @include(if:$includeUserIsYou)" json:"is_you"`
-	Location                              string                       `graphql:"location @include(if:$includeUserLocation)" json:"location"`
+	Location                              string                       `graphql:"location @include(if:$includeUserLocation)" json:"location,omitempty"`
 	MonthlyEstimatedSponsorsIncomeInCents int                          `graphql:"monthlyEstimatedSponsorsIncomeInCents @include(if:$includeUserMonthlyEstimatedSponsorsIncomeInCents)" json:"monthly_estimated_sponsors_income_in_cents"`
 	PinnedItemsRemaining                  int                          `graphql:"pinnedItemsRemaining @include(if:$includeUserPinnedItemsRemaining)" json:"pinned_items_remaining"`
 	ProjectsUrl                           string                       `graphql:"projectsUrl @include(if:$includeUserProjectsUrl)" json:"projects_url"`
@@ -146,7 +146,7 @@ type BaseUser struct {
 	Company                               string                       `json:"company"`
 	EstimatedNextSponsorsPayoutInCents    int                          `json:"estimated_next_sponsors_payout_in_cents"`
 	HasSponsorsListing                    bool                         `json:"has_sponsors_listing"`
-	InteractionAbility                    RepositoryInteractionAbility `json:"interaction_ability,omitempty"`
+	InteractionAbility                    RepositoryInteractionAbility `graphql:"interactionAbility @include(if:$includeUserInteractionAbility)" json:"interaction_ability,omitempty"`
 	IsBountyHunter                        bool                         `json:"is_bounty_hunter"`
 	IsCampusExpert                        bool                         `json:"is_campus_expert"`
 	IsDeveloperProgramMember              bool                         `json:"is_developer_program_member"`

--- a/github/repo_utils.go
+++ b/github/repo_utils.go
@@ -432,7 +432,7 @@ func appendRepoColumnIncludes(m *map[string]interface{}, cols []string) {
 		"has_vulnerability_alerts_enabled": "includeHasVulnerabilityAlertsEnabled",
 		"has_wiki_enabled":                 "includeHasWikiEnabled",
 		"homepage_url":                     "includeHomepageUrl",
-		"interaction_ability":              "includeInteractionAbility",
+		"interaction_ability":              "includeUserInteractionAbility",
 		"is_archived":                      "includeIsArchived",
 		"is_blank_issues_enabled":          "includeIsBlankIssuesEnabled",
 		"is_disabled":                      "includeIsDisabled",

--- a/github/table_github_issue.go
+++ b/github/table_github_issue.go
@@ -165,12 +165,14 @@ func tableGitHubRepositoryIssueList(ctx context.Context, d *plugin.QueryData, h 
 		"filters":  filters,
 	}
 	appendIssueColumnIncludes(&variables, d.QueryContext.Columns)
+	appendUserInteractionAbilityForIssue(&variables, d.QueryContext.Columns, d)
 
 	client := connectV4(ctx, d)
 
 	for {
 		err := client.Query(ctx, &query, variables)
 		plugin.Logger(ctx).Debug(rateLimitLogString("github_issue", &query.RateLimit))
+		// && len(query.Repository.Issues.Nodes) == 0
 		if err != nil {
 			plugin.Logger(ctx).Error("github_issue", "api_error", err)
 			return nil, err

--- a/github/table_github_issue.go
+++ b/github/table_github_issue.go
@@ -172,7 +172,6 @@ func tableGitHubRepositoryIssueList(ctx context.Context, d *plugin.QueryData, h 
 	for {
 		err := client.Query(ctx, &query, variables)
 		plugin.Logger(ctx).Debug(rateLimitLogString("github_issue", &query.RateLimit))
-		// && len(query.Repository.Issues.Nodes) == 0
 		if err != nil {
 			plugin.Logger(ctx).Error("github_issue", "api_error", err)
 			return nil, err

--- a/github/table_github_my_issue.go
+++ b/github/table_github_my_issue.go
@@ -92,7 +92,7 @@ func tableGitHubMyIssueList(ctx context.Context, d *plugin.QueryData, h *plugin.
 	for {
 		err := client.Query(ctx, &query, variables)
 		plugin.Logger(ctx).Debug(rateLimitLogString("github_my_issue", &query.RateLimit))
-		if err != nil {
+		if err != nil && len(query.Viewer.Issues.Nodes)==0{
 			plugin.Logger(ctx).Error("github_my_issue", "api_error", err)
 			return nil, err
 		}

--- a/github/table_github_my_issue.go
+++ b/github/table_github_my_issue.go
@@ -94,7 +94,7 @@ func tableGitHubMyIssueList(ctx context.Context, d *plugin.QueryData, h *plugin.
 	for {
 		err := client.Query(ctx, &query, variables)
 		plugin.Logger(ctx).Debug(rateLimitLogString("github_my_issue", &query.RateLimit))
-		if err != nil && len(query.Viewer.Issues.Nodes) == 0 {
+		if err != nil {
 			plugin.Logger(ctx).Error("github_my_issue", "api_error", err)
 			return nil, err
 		}

--- a/github/table_github_my_issue.go
+++ b/github/table_github_my_issue.go
@@ -3,11 +3,12 @@ package github
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
-	"time"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 )
@@ -86,13 +87,14 @@ func tableGitHubMyIssueList(ctx context.Context, d *plugin.QueryData, h *plugin.
 		"filters":  filters,
 	}
 	appendIssueColumnIncludes(&variables, d.QueryContext.Columns)
+	appendUserInteractionAbilityForIssue(&variables, d.QueryContext.Columns, d)
 
 	client := connectV4(ctx, d)
 
 	for {
 		err := client.Query(ctx, &query, variables)
 		plugin.Logger(ctx).Debug(rateLimitLogString("github_my_issue", &query.RateLimit))
-		if err != nil && len(query.Viewer.Issues.Nodes)==0{
+		if err != nil && len(query.Viewer.Issues.Nodes) == 0 {
 			plugin.Logger(ctx).Error("github_my_issue", "api_error", err)
 			return nil, err
 		}

--- a/github/table_github_pull_request.go
+++ b/github/table_github_pull_request.go
@@ -154,6 +154,7 @@ func tableGitHubPullRequestList(ctx context.Context, d *plugin.QueryData, h *plu
 		"states":   states,
 	}
 	appendPullRequestColumnIncludes(&variables, d.QueryContext.Columns)
+	appendUserInteractionAbilityForIssue(&variables, d.QueryContext.Columns, d)
 
 	client := connectV4(ctx, d)
 

--- a/github/table_github_repository.go
+++ b/github/table_github_repository.go
@@ -132,6 +132,7 @@ func tableGitHubRepositoryList(ctx context.Context, d *plugin.QueryData, h *plug
 		"name":  githubv4.String(repoName),
 	}
 	appendRepoColumnIncludes(&variables, d.QueryContext.Columns)
+	appendUserInteractionAbilityForIssue(&variables, d.QueryContext.Columns, d)
 
 	err := client.Query(ctx, &query, variables)
 	plugin.Logger(ctx).Debug(rateLimitLogString("github_repository", &query.RateLimit))

--- a/github/table_github_repository_dependabot_alert.go
+++ b/github/table_github_repository_dependabot_alert.go
@@ -45,7 +45,7 @@ func tableGitHubRepositoryDependabotAlert() *plugin.Table {
 		},
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.AllColumns([]string{"repository_full_name", "alert_number"}),
-			ShouldIgnoreError: isNotFoundError([]string{"404", "403"}),
+			ShouldIgnoreError: isNotFoundError([]string{"404"}),
 			Hydrate:           tableGitHubRepositoryDependabotAlertGet,
 		},
 		Columns: commonColumns(append(

--- a/github/table_github_repository_dependabot_alert.go
+++ b/github/table_github_repository_dependabot_alert.go
@@ -40,7 +40,7 @@ func tableGitHubRepositoryDependabotAlert() *plugin.Table {
 					Require: plugin.Optional,
 				},
 			},
-			ShouldIgnoreError: isNotFoundError([]string{"404", "403"}),
+			ShouldIgnoreError: isNotFoundError([]string{"404"}),
 			Hydrate:           tableGitHubRepositoryDependabotAlertList,
 		},
 		Get: &plugin.GetConfig{

--- a/github/table_github_repository_sbom.go
+++ b/github/table_github_repository_sbom.go
@@ -19,7 +19,7 @@ func tableGitHubRepositorySbom() *plugin.Table {
 					Require: plugin.Required,
 				},
 			},
-			ShouldIgnoreError: isNotFoundError([]string{"404", "403"}),
+			ShouldIgnoreError: isNotFoundError([]string{"404"}),
 			Hydrate:           listRepositorySboms,
 		},
 		Columns: commonColumns([]*plugin.Column{

--- a/github/table_github_search_issue.go
+++ b/github/table_github_search_issue.go
@@ -48,6 +48,7 @@ func tableGitHubSearchIssueList(ctx context.Context, d *plugin.QueryData, h *plu
 		"query":    githubv4.String(input),
 	}
 	appendIssueColumnIncludes(&variables, d.QueryContext.Columns)
+	appendUserInteractionAbilityForIssue(&variables, d.QueryContext.Columns, d)
 
 	client := connectV4(ctx, d)
 	for {

--- a/github/table_github_search_pull_request.go
+++ b/github/table_github_search_pull_request.go
@@ -48,6 +48,7 @@ func tableGitHubSearchPullRequestList(ctx context.Context, d *plugin.QueryData, 
 		"query":    githubv4.String(input),
 	}
 	appendPullRequestColumnIncludes(&variables, d.QueryContext.Columns)
+	appendUserInteractionAbilityForIssue(&variables, d.QueryContext.Columns, d)
 
 	client := connectV4(ctx, d)
 	for {

--- a/github/table_github_search_repository.go
+++ b/github/table_github_search_repository.go
@@ -48,6 +48,7 @@ func tableGitHubSearchRepositoryList(ctx context.Context, d *plugin.QueryData, h
 		"query":    githubv4.String(input),
 	}
 	appendRepoColumnIncludes(&variables, d.QueryContext.Columns)
+	appendUserInteractionAbilityForIssue(&variables, d.QueryContext.Columns, d)
 
 	client := connectV4(ctx, d)
 	for {

--- a/github/utils.go
+++ b/github/utils.go
@@ -75,14 +75,14 @@ func connect(ctx context.Context, d *plugin.QueryData) *github.Client {
 
 	// Return error for unsupported token by prefix
 	// https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats
-	if token != "" && !strings.HasPrefix(token, "ghs_") && !strings.HasPrefix(token, "ghp_") && !strings.HasPrefix(token, "gho_") {
-		panic("Supported token formats are 'ghs_', 'gho_', and 'ghp_'")
+	if token != "" && !strings.HasPrefix(token, "ghs_") && !strings.HasPrefix(token, "ghp_") && !strings.HasPrefix(token, "gho_") && !strings.HasPrefix(token, "github_pat") {
+		panic("Supported token formats are 'ghs_', 'gho_', 'ghp_', and 'github_pat'")
 	}
 
 	var client *github.Client
 
 	// Authentication with Github access token
-	if token != "" && strings.HasPrefix(token, "ghp_") {
+	if token != "" && (strings.HasPrefix(token, "ghp_") || strings.HasPrefix(token, "github_pat")){
 		ts := oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: token},
 		)
@@ -191,8 +191,8 @@ func connectV4(ctx context.Context, d *plugin.QueryData) *githubv4.Client {
 
 	// Return error for unsupported token by prefix
 	// https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#githubs-token-formats
-	if token != "" && !strings.HasPrefix(token, "ghs_") && !strings.HasPrefix(token, "ghp_") && !strings.HasPrefix(token, "gho_") {
-		panic("Supported token formats are 'ghs_', 'gho_', and 'ghp_'")
+	if token != "" && !strings.HasPrefix(token, "ghs_") && !strings.HasPrefix(token, "ghp_") && !strings.HasPrefix(token, "gho_") && !strings.HasPrefix(token, "github_pat") {
+		panic("Supported token formats are 'ghs_', 'gho_', 'ghp_', and 'github_pat'")
 	}
 
 	var client *githubv4.Client
@@ -207,7 +207,7 @@ func connectV4(ctx context.Context, d *plugin.QueryData) *githubv4.Client {
 	var transport *ghinstallation.Transport
 
 	// Authentication with Github access token
-	if token != "" && strings.HasPrefix(token, "ghp_") {
+	if token != "" && (strings.HasPrefix(token, "ghp_") || strings.HasPrefix(token, "github_pat")) {
 		ts := oauth2.StaticTokenSource(
 			&oauth2.Token{AccessToken: token},
 		)


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from github_repository where full_name = 'pro-cloud-49/access-control'
+----------------------+-----------------------------+-----------+--------------+----------------+---------------------+-------------+--------------------+-----------------+---------------+----------->
| login_id             | full_name                   | id        | node_id      | name           | allow_update_branch | archived_at | auto_merge_allowed | code_of_conduct | contact_links | created_at>
+----------------------+-----------------------------+-----------+--------------+----------------+---------------------+-------------+--------------------+-----------------+---------------+----------->
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/access-control | 455455299 | R_kgDOGyWyQw | access-control | false               | <null>      | false              | <null>          | <null>        | 2022-02-04>
+----------------------+-----------------------------+-----------+--------------+----------------+---------------------+-------------+--------------------+-----------------+---------------+----------->

Time: 2.0s. Rows returned: 0. Rows fetched: 1. Hydrate calls: 70.

Scans:
  1) github_repository.github: Time: 1.9s. Fetched: 1. Hydrates: 70. Quals: full_name=pro-cloud-49/access-control.

> select * from github_issue where repository_full_name = 'pro-cloud-49/access-control'
+----------+----------------------+--------+----+---------+--------------------+--------+--------------+--------------------+------+----------+--------+-----------+------------+-------------------+--->
| login_id | repository_full_name | number | id | node_id | active_lock_reason | author | author_login | author_association | body | body_url | closed | closed_at | created_at | created_via_email | ed>
+----------+----------------------+--------+----+---------+--------------------+--------+--------------+--------------------+------+----------+--------+-----------+------------+-------------------+--->
+----------+----------------------+--------+----+---------+--------------------+--------+--------------+--------------------+------+----------+--------+-----------+------------+-------------------+--->

Time: 1.1s. Rows returned: 0.
> select * from github_issue where repository_full_name = 'pro-cloud-49/test37'
+----------------------+----------------------+--------+------------+--------------------+--------------------+----------------------------------------------------------------------------------------->
| login_id             | repository_full_name | number | id         | node_id            | active_lock_reason | author                                                                                  >
+----------------------+----------------------+--------+------------+--------------------+--------------------+----------------------------------------------------------------------------------------->
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 5      | 1949715100 | I_kwDOKhSWUs50Nkqc |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 2      | 1949715095 | I_kwDOKhSWUs50NkqX |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 3      | 1949715096 | I_kwDOKhSWUs50NkqY |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 1      | 1949715090 | I_kwDOKhSWUs50NkqS |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 4      | 1949715098 | I_kwDOKhSWUs50Nkqa |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 43     | 1949771555 | I_kwDOKhSWUs50Nycj |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
|                      |                      |        |            |                    |                    |                                                                                         >
|                      |                      |        |            |                    |                    |                                                                                         >
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 41     | 1949769391 | I_kwDOKhSWUs50Nx6v |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
|                      |                      |        |            |                    |                    |                                                                                         >
|                      |                      |        |            |                    |                    |                                                                                         >
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 10     | 1949715111 | I_kwDOKhSWUs50Nkqn |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 45     | 1949771564 | I_kwDOKhSWUs50Nycs |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
|                      |                      |        |            |                    |                    |                                                                                         >
|                      |                      |        |            |                    |                    |                                                                                         >
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 37     | 1949769384 | I_kwDOKhSWUs50Nx6o |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>
|                      |                      |        |            |                    |                    |                                                                                         >
|                      |                      |        |            |                    |                    |                                                                                         >
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 44     | 1949771556 | I_kwDOKhSWUs50Nyck |                    | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db9a206103d83fe>

Time: 7.2s. Rows returned: 0. Rows fetched: 151. Hydrate calls: 6,040.

Scans:
  1) github_issue.github: Time: 7.2s. Fetched: 151. Hydrates: 6,040. Quals: repository_full_name=pro-cloud-49/test37.

> select * from github_pull_request where repository_full_name = 'pro-cloud-49/test37'
+----------------------+----------------------+--------+------------+---------------------+--------------------+-----------+---------------------------------------------------------------------------->
| login_id             | repository_full_name | number | id         | node_id             | active_lock_reason | additions | author                                                                     >
+----------------------+----------------------+--------+------------+---------------------+--------------------+-----------+---------------------------------------------------------------------------->
| MDQ6VXNlcjQ3ODg3NTUy | pro-cloud-49/test37  | 72     | 1691085842 | PR_kwDOKhSWUs5ky-wS |                    | 1         | {"avatar_url":"https://avatars.githubusercontent.com/u/47887552?u=2722299db>
|                      |                      |        |            |                     |                    |           |                                                                            >
+----------------------+----------------------+--------+------------+---------------------+--------------------+-----------+---------------------------------------------------------------------------->

Time: 1.2s. Rows returned: 0. Rows fetched: 1. Hydrate calls: 66.

Scans:
  1) github_pull_request.github: Time: 1.1s. Fetched: 1. Hydrates: 66. Quals: repository_full_name=pro-cloud-49/test37.

```
</details>
