### PR TITLE
Add table github_repository_discussion Closes #510

### DIFF
--- a/docs/tables/github_repository_discussion.md
+++ b/docs/tables/github_repository_discussion.md
@@ -1,0 +1,367 @@
+---
+title: "Steampipe Table: github_repository_discussion - Query GitHub Repository Discussions using SQL"
+description: "Allows users to query GitHub Repository Discussions, providing insights into discussions, comments, and replies within repositories."
+folder: "Repository"
+---
+
+# Table: github_repository_discussion - Query GitHub Repository Discussions using SQL
+
+GitHub Discussions are conversations that can be started by anyone and are organized into categories. They provide a place for having conversations that are not issues or pull requests. Discussions can be used to ask questions, share ideas, or have general conversations about a project.
+
+## Table Usage Guide
+
+The `github_repository_discussion` table provides insights into discussions within GitHub repositories. As a project manager or developer, explore discussion-specific details through this table, including comments, replies, categories, and associated metadata. Utilize it to uncover information about discussions, such as those with the most engagement, discussions by category, and the overall activity within a repository's discussion forum.
+
+To query this table using a [fine-grained access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token), the following permissions are required:
+
+- Repository permissions:
+  - Discussions (Read-only): Required to access all columns.
+
+**Important Notes**
+- You must specify the `repository_full_name` (owner/repository) column in the `where` or `join` clause to query the table.
+
+## Examples
+
+### List discussions in a repository
+Explore the discussions within a specific GitHub repository to understand community engagement and topics being discussed. This can help in tracking community activity and identifying popular discussion topics.
+
+```sql+postgres
+select
+  number,
+  title,
+  author_login,
+  category_name,
+  created_at,
+  comments_total_count
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe';
+```
+
+```sql+sqlite
+select
+  number,
+  title,
+  author_login,
+  category_name,
+  created_at,
+  comments_total_count
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe';
+```
+
+### Get a specific discussion by number
+Retrieve detailed information about a specific discussion, including its full content, author details, and engagement metrics. This is useful for analyzing individual discussion threads and understanding their impact.
+
+```sql+postgres
+select
+  number,
+  title,
+  author_login,
+  category_name,
+  created_at,
+  comments_total_count,
+  answer
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and number = 1007;
+```
+
+```sql+sqlite
+select
+  number,
+  title,
+  author_login,
+  category_name,
+  created_at,
+  comments_total_count,
+  answer
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and number = 1007;
+```
+
+### Find discussions with answers
+Identify discussions that have been answered, which can help in understanding which topics have been resolved and which discussions have received helpful responses from the community.
+
+```sql+postgres
+select
+  number,
+  title,
+  author_login,
+  category_name,
+  answer
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and answer is not null;
+```
+
+```sql+sqlite
+select
+  number,
+  title,
+  author_login,
+  category_name,
+  answer
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and answer is not null;
+```
+
+### Find discussions by category
+Filter discussions by their category to focus on specific types of conversations, such as FAQs, feature requests, or general discussions. This helps in organizing and prioritizing community feedback.
+
+```sql+postgres
+select
+  number,
+  title,
+  author_login,
+  category_name,
+  created_at
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and category_name = 'FAQ';
+```
+
+```sql+sqlite
+select
+  number,
+  title,
+  author_login,
+  category_name,
+  created_at
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and category_name = 'FAQ';
+```
+
+### Get all comments for a discussion
+Retrieve all comments for a specific discussion to understand the full conversation thread and community engagement. This includes both the comment content and metadata about each comment.
+
+```sql+postgres
+select
+  number,
+  title,
+  comments
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and number = 1007;
+```
+
+```sql+sqlite
+select
+  number,
+  title,
+  comments
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and number = 1007;
+```
+
+### Get all replies for a discussion
+Retrieve all replies to comments in a specific discussion to understand the nested conversation structure and identify threads with high engagement.
+
+```sql+postgres
+select
+  number,
+  title,
+  replies
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and number = 1007;
+```
+
+```sql+sqlite
+select
+  number,
+  title,
+  replies
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and number = 1007;
+```
+
+### Find discussions with the most comments
+Identify the most active discussions in a repository by sorting by comment count. This helps in understanding which topics generate the most community engagement and discussion.
+
+```sql+postgres
+select
+  number,
+  title,
+  author_login,
+  comments_total_count
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+order by
+  comments_total_count desc
+limit 10;
+```
+
+```sql+sqlite
+select
+  number,
+  title,
+  author_login,
+  comments_total_count
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+order by
+  comments_total_count desc
+limit 10;
+```
+
+### Find recent discussions
+Identify recently created discussions to stay updated on the latest community activity and new topics being discussed in the repository.
+
+```sql+postgres
+select
+  number,
+  title,
+  author_login,
+  created_at
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and created_at > now() - interval '30 days'
+order by
+  created_at desc;
+```
+
+```sql+sqlite
+select
+  number,
+  title,
+  author_login,
+  created_at
+from
+  github_repository_discussion
+where
+  repository_full_name = 'turbot/steampipe'
+  and created_at > datetime('now', '-30 days')
+order by
+  created_at desc;
+```
+
+## Schema for table github_repository_discussion
+
+| Column                 | Type                       | Rules                                                 |
+| ---------------------- | -------------------------- | ----------------------------------------------------- |
+| `repository_full_name` | `text`                     | `NOT NULL`                                            |
+| `id`                   | `bigint`                   |                                                       |
+| `node_id`              | `text`                     |                                                       |
+| `number`               | `bigint`                   |                                                       |
+| `title`                | `text`                     |                                                       |
+| `url`                  | `text`                     |                                                       |
+| `created_at`           | `timestamp with time zone` |                                                       |
+| `updated_at`           | `timestamp with time zone` |                                                       |
+| `author`               | `jsonb`                    |                                                       |
+| `author_login`         | `text`                     |                                                       |
+| `category`             | `jsonb`                    |                                                       |
+| `category_name`        | `text`                     |                                                       |
+| `answer`               | `jsonb`                    |                                                       |
+| `comments_total_count` | `bigint`                   |                                                       |
+| `comments`             | `jsonb`                    |                                                       |
+| `replies`              | `jsonb`                    |                                                       |
+| `_ctx`                 | `jsonb`                    | Steampipe context in JSON form, e.g. connection_name. |
+
+## Column details
+
+### `repository_full_name`
+The full name of the repository (login/repo-name). This is a required qualifier for all queries.
+
+### `id`
+The numeric ID of the discussion.
+
+### `node_id`
+The node ID of the discussion (GraphQL global node ID).
+
+### `number`
+The discussion number within the repository.
+
+### `title`
+The title of the discussion.
+
+### `url`
+The URL of the discussion.
+
+### `created_at`
+Timestamp when the discussion was created.
+
+### `updated_at`
+Timestamp when the discussion was last updated.
+
+### `author`
+The actor who authored the discussion. Contains:
+
+- `login`: The username of the author
+- `avatar_url`: URL to the author's avatar
+- `url`: URL to the author's profile
+
+### `author_login`
+The login (username) of the discussion author.
+
+### `category`
+The category of the discussion. Contains:
+
+- `name`: The name of the discussion category
+
+### `category_name`
+The name of the discussion category (e.g., "FAQ", "Ideas / Feature Requests").
+
+### `answer`
+The answer to the discussion, if any. Contains the full discussion comment that was marked as the answer.
+
+### `comments_total_count`
+Total count of comments on the discussion.
+
+### `comments`
+All comments on the discussion (paginated, no limit). Each comment contains:
+
+- `id`: The numeric ID of the comment
+- `node_id`: The GraphQL node ID of the comment
+- `author`: The author of the comment
+- `body`: The comment body (HTML)
+- `body_text`: The comment body (plain text)
+- `created_at`: When the comment was created
+- `updated_at`: When the comment was last updated
+- `is_answer`: Whether this comment is the answer to the discussion
+
+### `replies`
+All replies to comments on the discussion (paginated, no limit). Each reply contains:
+
+- `id`: The numeric ID of the reply
+- `node_id`: The GraphQL node ID of the reply
+- `author`: The author of the reply
+- `body`: The reply body (HTML)
+- `body_text`: The reply body (plain text)
+- `created_at`: When the reply was created
+- `updated_at`: When the reply was last updated
+- `is_answer`: Whether this reply is an answer

--- a/github/models/discussion.go
+++ b/github/models/discussion.go
@@ -1,0 +1,47 @@
+package models
+
+type Discussion struct {
+	Id        int          `graphql:"id: databaseId" json:"id"`
+	NodeId    string       `graphql:"nodeId: id" json:"node_id"`
+	Number    int          `graphql:"number" json:"number"`
+	Title     string       `graphql:"title" json:"title"`
+	Url       string       `graphql:"url" json:"url"`
+	CreatedAt NullableTime `graphql:"createdAt" json:"created_at"`
+	UpdatedAt NullableTime `graphql:"updatedAt" json:"updated_at"`
+	Author    Actor        `graphql:"author" json:"author"`
+	Category  struct {
+		Name string `graphql:"name" json:"name"`
+	} `graphql:"category" json:"category"`
+	Answer   *DiscussionComment `graphql:"answer" json:"answer"`
+	Comments struct {
+		TotalCount int
+		Nodes      []DiscussionComment
+	} `graphql:"comments(first: 100)" json:"comments"`
+}
+
+type DiscussionComments struct {
+	Comments struct {
+		PageInfo   PageInfo
+		TotalCount int
+		Nodes      []DiscussionComment
+	} `graphql:"comments(first: $pageSize, after: $cursor)"`
+}
+
+type DiscussionCommentReplies struct {
+	Replies struct {
+		PageInfo   PageInfo
+		TotalCount int
+		Nodes      []DiscussionComment
+	} `graphql:"replies(first: $pageSize, after: $cursor)"`
+}
+
+type DiscussionComment struct {
+	Id        int          `graphql:"id: databaseId" json:"id"`
+	NodeId    string       `graphql:"nodeId: id" json:"node_id"`
+	Author    Actor        `graphql:"author" json:"author"`
+	Body      string       `graphql:"body" json:"body"`
+	BodyText  string       `graphql:"bodyText" json:"body_text"`
+	CreatedAt NullableTime `graphql:"createdAt" json:"created_at"`
+	UpdatedAt NullableTime `graphql:"updatedAt" json:"updated_at"`
+	IsAnswer  bool         `graphql:"isAnswer" json:"is_answer"`
+}

--- a/github/plugin.go
+++ b/github/plugin.go
@@ -63,6 +63,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"github_repository_content":              tableGitHubRepositoryContent(),
 			"github_repository_dependabot_alert":     tableGitHubRepositoryDependabotAlert(),
 			"github_repository_deployment":           tableGitHubRepositoryDeployment(),
+			"github_repository_discussion":           tableGitHubRepositoryDiscussion(),
 			"github_repository_environment":          tableGitHubRepositoryEnvironment(),
 			"github_repository_ruleset":              tableGitHubRepositoryRuleset(),
 			"github_repository_sbom":                 tableGitHubRepositorySbom(),

--- a/github/table_github_repository_discussion.go
+++ b/github/table_github_repository_discussion.go
@@ -1,0 +1,349 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/shurcooL/githubv4"
+	"github.com/turbot/steampipe-plugin-github/github/models"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func gitHubRepositoryDiscussionColumns() []*plugin.Column {
+	return []*plugin.Column{
+		{Name: "repository_full_name", Type: proto.ColumnType_STRING, Transform: transform.FromQual("repository_full_name"), Description: "The full name of the repository (login/repo-name)."},
+		{Name: "id", Type: proto.ColumnType_INT, Transform: transform.FromField("Id"), Description: "The ID of the discussion."},
+		{Name: "node_id", Type: proto.ColumnType_STRING, Transform: transform.FromField("NodeId"), Description: "The node ID of the discussion."},
+		{Name: "number", Type: proto.ColumnType_INT, Description: "The discussion number."},
+		{Name: "title", Type: proto.ColumnType_STRING, Description: "The title of the discussion."},
+		{Name: "url", Type: proto.ColumnType_STRING, Transform: transform.FromField("Url"), Description: "The URL of the discussion."},
+		{Name: "created_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("CreatedAt").NullIfZero().Transform(convertTimestamp), Description: "Timestamp when the discussion was created."},
+		{Name: "updated_at", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("UpdatedAt").NullIfZero().Transform(convertTimestamp), Description: "Timestamp when the discussion was last updated."},
+		{Name: "author", Type: proto.ColumnType_JSON, Description: "The actor who authored the discussion."},
+		{Name: "author_login", Type: proto.ColumnType_STRING, Transform: transform.FromField("Author.Login"), Description: "The login of the discussion author."},
+		{Name: "category", Type: proto.ColumnType_JSON, Description: "The category of the discussion."},
+		{Name: "category_name", Type: proto.ColumnType_STRING, Transform: transform.FromField("Category.Name"), Description: "The name of the discussion category."},
+		{Name: "answer", Type: proto.ColumnType_JSON, Description: "The answer to the discussion, if any."},
+		{Name: "comments_total_count", Type: proto.ColumnType_INT, Transform: transform.FromField("Comments.TotalCount"), Description: "Total count of comments on the discussion."},
+		{Name: "comments", Type: proto.ColumnType_JSON, Hydrate: discussionHydrateComments, Transform: transform.FromValue().NullIfZero(), Description: "All comments on the discussion."},
+		{Name: "replies", Type: proto.ColumnType_JSON, Hydrate: discussionHydrateReplies, Transform: transform.FromValue().NullIfZero(), Description: "All replies to comments on the discussion."},
+	}
+}
+
+func tableGitHubRepositoryDiscussion() *plugin.Table {
+	return &plugin.Table{
+		Name:        "github_repository_discussion",
+		Description: "GitHub Discussions are conversations that can be started by anyone and are organized into categories.",
+		List: &plugin.ListConfig{
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "repository_full_name",
+					Require: plugin.Required,
+				},
+			},
+			ShouldIgnoreError: isNotFoundError([]string{"404"}),
+			Hydrate:           tableGitHubRepositoryDiscussionList,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns:        plugin.AllColumns([]string{"repository_full_name", "number"}),
+			ShouldIgnoreError: isNotFoundError([]string{"404"}),
+			Hydrate:           tableGitHubRepositoryDiscussionGet,
+		},
+		Columns: commonColumns(gitHubRepositoryDiscussionColumns()),
+	}
+}
+
+//// LIST FUNCTION
+
+func tableGitHubRepositoryDiscussionList(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	quals := d.EqualsQuals
+	fullName := quals["repository_full_name"].GetStringValue()
+	owner, repoName := parseRepoFullName(fullName)
+
+	// First, let's check if the repository has discussions enabled
+	var checkQuery struct {
+		RateLimit  models.RateLimit
+		Repository struct {
+			Id                    int `graphql:"id: databaseId"`
+			Name                  string
+			HasDiscussionsEnabled bool `graphql:"hasDiscussionsEnabled"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	checkVariables := map[string]interface{}{
+		"owner": githubv4.String(owner),
+		"name":  githubv4.String(repoName),
+	}
+
+	client := connectV4(ctx, d)
+
+	// Check repository and discussions status
+	err := client.Query(ctx, &checkQuery, checkVariables)
+	if err != nil {
+		plugin.Logger(ctx).Error("github_repository_discussion", "check_api_error", err, "repository", fullName)
+		return nil, err
+	}
+
+	if !checkQuery.Repository.HasDiscussionsEnabled {
+		plugin.Logger(ctx).Info("github_repository_discussion", "discussions_not_enabled", "repository", fullName)
+		return nil, nil
+	}
+
+	// Now query discussions with minimal fields
+	pageSize := adjustPageSize(100, d.QueryContext.Limit)
+
+	var query struct {
+		RateLimit  models.RateLimit
+		Repository struct {
+			Discussions struct {
+				PageInfo   models.PageInfo
+				TotalCount int
+				Nodes      []models.Discussion
+			} `graphql:"discussions(first: $pageSize, after: $cursor)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner":    githubv4.String(owner),
+		"name":     githubv4.String(repoName),
+		"pageSize": githubv4.Int(pageSize),
+		"cursor":   (*githubv4.String)(nil),
+	}
+
+	for {
+		err := client.Query(ctx, &query, variables)
+		plugin.Logger(ctx).Debug(rateLimitLogString("github_repository_discussion", &query.RateLimit))
+		if err != nil {
+			plugin.Logger(ctx).Error("github_repository_discussion", "api_error", err, "repository", fullName)
+			return nil, err
+		}
+
+		for _, discussion := range query.Repository.Discussions.Nodes {
+			d.StreamListItem(ctx, discussion)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+
+		if !query.Repository.Discussions.PageInfo.HasNextPage {
+			break
+		}
+		variables["cursor"] = githubv4.NewString(query.Repository.Discussions.PageInfo.EndCursor)
+	}
+
+	return nil, nil
+}
+
+/// HYDRATE FUNCTION
+
+func tableGitHubRepositoryDiscussionGet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	quals := d.EqualsQuals
+	discussionNumber := int(quals["number"].GetInt64Value())
+	fullName := quals["repository_full_name"].GetStringValue()
+	owner, repoName := parseRepoFullName(fullName)
+
+	var query struct {
+		RateLimit  models.RateLimit
+		Repository struct {
+			Discussion models.Discussion `graphql:"discussion(number: $number)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner":  githubv4.String(owner),
+		"name":   githubv4.String(repoName),
+		"number": githubv4.Int(discussionNumber),
+	}
+
+	client := connectV4(ctx, d)
+
+	err := client.Query(ctx, &query, variables)
+	plugin.Logger(ctx).Debug(rateLimitLogString("github_repository_discussion", &query.RateLimit))
+	if err != nil {
+		plugin.Logger(ctx).Error("github_repository_discussion", "api_error", err)
+		return nil, err
+	}
+
+	return query.Repository.Discussion, nil
+}
+
+func discussionHydrateComments(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	discussion := h.Item.(models.Discussion)
+
+	// check if the the LIST API already fetched all the comments
+	if discussion.Comments.TotalCount == len(discussion.Comments.Nodes) {
+		return discussion.Comments.Nodes, nil
+	}
+
+	// Parse repository info from the discussion URL
+	// URL format: https://github.com/owner/repo/discussions/123
+	urlParts := strings.Split(discussion.Url, "/")
+	if len(urlParts) < 5 {
+		return nil, fmt.Errorf("invalid discussion URL format")
+	}
+
+	owner := urlParts[3]
+	repoName := urlParts[4]
+
+	pageSize := adjustPageSize(100, d.QueryContext.Limit)
+
+	var query struct {
+		RateLimit  models.RateLimit
+		Repository struct {
+			Discussion struct {
+				Comments struct {
+					PageInfo   models.PageInfo
+					TotalCount int
+					Nodes      []models.DiscussionComment
+				} `graphql:"comments(first: $pageSize, after: $cursor)"`
+			} `graphql:"discussion(number: $number)"`
+		} `graphql:"repository(owner: $owner, name: $name)"`
+	}
+
+	variables := map[string]interface{}{
+		"owner":    githubv4.String(owner),
+		"name":     githubv4.String(repoName),
+		"number":   githubv4.Int(discussion.Number),
+		"pageSize": githubv4.Int(pageSize),
+		"cursor":   (*githubv4.String)(nil),
+	}
+
+	client := connectV4(ctx, d)
+	var allComments []models.DiscussionComment
+
+	for {
+		err := client.Query(ctx, &query, variables)
+		plugin.Logger(ctx).Debug(rateLimitLogString("github_repository_discussion_comments", &query.RateLimit))
+		if err != nil {
+			plugin.Logger(ctx).Error("github_repository_discussion_comments", "api_error", err)
+			return nil, err
+		}
+
+		allComments = append(allComments, query.Repository.Discussion.Comments.Nodes...)
+
+		if !query.Repository.Discussion.Comments.PageInfo.HasNextPage {
+			break
+		}
+		variables["cursor"] = githubv4.NewString(query.Repository.Discussion.Comments.PageInfo.EndCursor)
+	}
+
+	return allComments, nil
+}
+
+func discussionHydrateReplies(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	discussion := h.Item.(models.Discussion)
+	discussionNumber := discussion.Number
+
+	var commentNodeIds []string
+	// Check if the LIST API already fetched all comments the collect all node IDs from the discussion
+	if discussion.Comments.TotalCount == len(discussion.Comments.Nodes) {
+		for _, nodeId := range discussion.Comments.Nodes {
+			commentNodeIds = append(commentNodeIds, nodeId.NodeId)
+		}
+	}
+
+	// Parse repository info from the discussion URL
+	// URL format: https://github.com/owner/repo/discussions/123
+	urlParts := strings.Split(discussion.Url, "/")
+	if len(urlParts) < 5 {
+		return nil, fmt.Errorf("invalid discussion URL format")
+	}
+	pageSize := adjustPageSize(100, d.QueryContext.Limit)
+	client := connectV4(ctx, d)
+
+	// if the commentNodeIds is empty, we need to fetch all the comment node IDs from the discussion
+	// Step 1: Get all comment node IDs from the discussion
+	if len(commentNodeIds) == 0 {
+		owner := urlParts[3]
+		repoName := urlParts[4]
+
+		var commentsQuery struct {
+			RateLimit  models.RateLimit
+			Repository struct {
+				Discussion struct {
+					Comments struct {
+						PageInfo   models.PageInfo
+						TotalCount int
+						Nodes      []struct {
+							NodeId string `graphql:"nodeId: id"`
+						}
+					} `graphql:"comments(first: $pageSize, after: $cursor)"`
+				} `graphql:"discussion(number: $number)"`
+			} `graphql:"repository(owner: $owner, name: $name)"`
+		}
+
+		commentsVariables := map[string]interface{}{
+			"owner":    githubv4.String(owner),
+			"name":     githubv4.String(repoName),
+			"number":   githubv4.Int(discussionNumber),
+			"pageSize": githubv4.Int(pageSize),
+			"cursor":   (*githubv4.String)(nil),
+		}
+
+		// Collect all comment node IDs
+		for {
+			err := client.Query(ctx, &commentsQuery, commentsVariables)
+			plugin.Logger(ctx).Debug(rateLimitLogString("github_repository_discussion_comments_for_replies", &commentsQuery.RateLimit))
+			if err != nil {
+				plugin.Logger(ctx).Error("github_repository_discussion_comments_for_replies", "api_error", err)
+				return nil, err
+			}
+
+			for _, comment := range commentsQuery.Repository.Discussion.Comments.Nodes {
+				commentNodeIds = append(commentNodeIds, comment.NodeId)
+			}
+
+			if !commentsQuery.Repository.Discussion.Comments.PageInfo.HasNextPage {
+				break
+			}
+			commentsVariables["cursor"] = githubv4.NewString(commentsQuery.Repository.Discussion.Comments.PageInfo.EndCursor)
+		}
+	}
+	// Step 2: Get replies for each comment node ID
+	var allReplies []models.DiscussionComment
+
+	for _, nodeId := range commentNodeIds {
+		var repliesQuery struct {
+			RateLimit models.RateLimit
+			Node      struct {
+				DiscussionComment struct {
+					Replies struct {
+						PageInfo   models.PageInfo
+						TotalCount int
+						Nodes      []models.DiscussionComment
+					} `graphql:"replies(first: $pageSize, after: $cursor)"`
+				} `graphql:"... on DiscussionComment"`
+			} `graphql:"node(id: $nodeId)"`
+		}
+
+		repliesVariables := map[string]interface{}{
+			"nodeId":   githubv4.ID(nodeId),
+			"pageSize": githubv4.Int(pageSize),
+			"cursor":   (*githubv4.String)(nil),
+		}
+
+		// Get replies for this comment with pagination
+		for {
+			err := client.Query(ctx, &repliesQuery, repliesVariables)
+			plugin.Logger(ctx).Debug(rateLimitLogString("github_repository_discussion_replies", &repliesQuery.RateLimit))
+			if err != nil {
+				plugin.Logger(ctx).Error("github_repository_discussion_replies", "api_error", err)
+				return nil, err
+			}
+
+			allReplies = append(allReplies, repliesQuery.Node.DiscussionComment.Replies.Nodes...)
+
+			if !repliesQuery.Node.DiscussionComment.Replies.PageInfo.HasNextPage {
+				break
+			}
+			repliesVariables["cursor"] = githubv4.NewString(repliesQuery.Node.DiscussionComment.Replies.PageInfo.EndCursor)
+		}
+	}
+
+	return allReplies, nil
+}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from github_repository_discussion where repository_full_name = 'aws/aws-sdk-js-v3'
+----------------------+----------------------+-----------+------------------------------+--------+--------------------------------------------------------------------------->
| login_id             | repository_full_name | id        | node_id                      | number | title                                                                     >
+----------------------+----------------------+-----------+------------------------------+--------+--------------------------------------------------------------------------->
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 8,583,710 | D_kwDOBTL-us4Agvoe           | 7,201  | Use AWS SDK JS v3 @aws-sdk/client-* (or) @aws-sdk/lib-* directly in browse>
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 8,620,359 | D_kwDOBTL-us4Ag4lH           | 7,221  | Multi turn conversation with chat history for AWS Bedrock converse API    >
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 8,425,549 | D_kwDOBTL-us4AgJBN           | 7,120  | TypeError: headers[headerName].trim is not a function in StartFaceLiveness>
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 7,521,724 | D_kwDOBTL-us4AcsW8           | 6,682  | `@smithy/eventstream-codec` Error: "Reported message length does not match>
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 6,020,943 | D_kwDOBTL-us4AW99P           | 5,634  | What's the difference?                                                    >
|                      |                      |           |                              |        |                                                                           >
|                      |                      |           |                              |        |                                                                           >
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 8,262,089 | D_kwDOBTL-us4AfhHJ           | 7,040  | Breaking change in client-bedrock-runtime                                 >
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 8,821,877 | D_kwDOBTL-us4Ahpx1           | 7,296  | CreateAgentCommand not saving the bedrock agent !!                        >
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 8,154,913 | D_kwDOBTL-us4AfG8h           | 6,990  | How to send signed AWS Elasticsearch request?                             >
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 8,228,665 | D_kwDOBTL-us4AfY85           | 7,021  | "TypeError: Object.defineProperty called on non-object" with versions newe>
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 7,062,324 | D_kwDOBTL-us4Aa8M0           | 6,391  | S3 - pre-signer Typescript Error                                          >
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 6,723,421 | D_kwDOBTL-us4AZpdd           | 6,137  | Health Imaging StartDICOMImportJob always processes entire bucket regardle>
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 8,133,584 | D_kwDOBTL-us4AfBvQ           | 6,979  | Client Bedrock Agent Runtime - Expose default prompt templates?           >
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 7,984,048 | D_kwDOBTL-us4AedOw           | 6,894  | Omitting or Over-Specifying maxSockets in lib-storage's Upload Class Cause>
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 7,832,822 | D_kwDOBTL-us4Ad4T2           | 6,814  | SDK consumers using an older esbuild version for bundling results in a run>
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 7,866,249 | D_kwDOBTL-us4AeAeJ           | 6,847  | Why DynamoDB Query not Returning any Items in Low-Level Client?           >
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 8,042,993 | D_kwDOBTL-us4Aernx           | 6,917  | Parameter to access s3 url only once                                      >
| MDQ6VXNlcjQ3ODg3NTUy | aws/aws-sdk-js-v3    | 7,828,678 | D_kwDOBTL-us4Ad3TG           | 6,808  | Announcement: S3 default integrity change                                 >
316 rows

Time: 16.8s. Rows returned: 316. Rows fetched: 316. Hydrate calls: 948.

Scans:
  1) github_repository_discussion.github: Time: 16.8s. Fetched: 316. Hydrates: 948. Quals: repository_full_name=aws/aws-sdk-js-v3.
```
</details>
