### PR TITLE
fix: removed unsupported `discussions_url` and `discussions_total_count` columns from the github_team table

### DIFF
--- a/github/models/team.go
+++ b/github/models/team.go
@@ -35,7 +35,6 @@ type TeamWithCounts struct {
 	Team
 	Ancestors    Count `graphql:"ancestors @include(if:$includeTeamAncestors)" json:"ancestors"`
 	ChildTeams   Count `graphql:"childTeams @include(if:$includeTeamChildTeams)" json:"child_teams"`
-	Discussions  Count `graphql:"discussions @include(if:$includeTeamDiscussions)" json:"discussions"`
 	Invitations  Count `graphql:"invitations @include(if:$includeTeamInvitations)" json:"invitations"`
 	Members      Count `graphql:"members @include(if:$includeTeamMembers)" json:"members"`
 	ProjectsV2   Count `graphql:"projectsV2 @include(if:$includeTeamProjectsV2)" json:"projects_v2"`

--- a/github/table_github_team.go
+++ b/github/table_github_team.go
@@ -27,7 +27,6 @@ func gitHubTeamColumns() []*plugin.Column {
 		{Name: "privacy", Type: proto.ColumnType_STRING, Description: "The privacy setting of the team (VISIBLE or SECRET).", Transform: transform.FromValue(), Hydrate: teamHydratePrivacy},
 		{Name: "ancestors_total_count", Type: proto.ColumnType_INT, Description: "Count of ancestors this team has.", Transform: transform.FromValue(), Hydrate: teamHydrateAncestorsTotalCount},
 		{Name: "child_teams_total_count", Type: proto.ColumnType_INT, Description: "Count of children teams this team has.", Transform: transform.FromValue(), Hydrate: teamHydrateChildTeamsTotalCount},
-		{Name: "discussions_total_count", Type: proto.ColumnType_INT, Description: "Count of team discussions.", Transform: transform.FromValue(), Hydrate: teamHydrateDiscussionsTotalCount},
 		{Name: "invitations_total_count", Type: proto.ColumnType_INT, Description: "Count of outstanding team member invitations for the team.", Transform: transform.FromValue(), Hydrate: teamHydrateInvitationsTotalCount},
 		{Name: "members_total_count", Type: proto.ColumnType_INT, Description: "Count of team members.", Transform: transform.FromValue(), Hydrate: teamHydrateMembersTotalCount},
 		{Name: "projects_v2_total_count", Type: proto.ColumnType_INT, Description: "Count of the teams v2 projects.", Transform: transform.FromValue(), Hydrate: teamHydrateProjectsV2TotalCount},

--- a/github/team_utils.go
+++ b/github/team_utils.go
@@ -37,7 +37,6 @@ func appendTeamColumnIncludes(m *map[string]interface{}, cols []string) {
 	(*m)["includeTeamSubscription"] = githubv4.Boolean(slices.Contains(cols, "subscription"))
 	(*m)["includeTeamAncestors"] = githubv4.Boolean(slices.Contains(cols, "ancestors_total_count"))
 	(*m)["includeTeamChildTeams"] = githubv4.Boolean(slices.Contains(cols, "child_teams_total_count"))
-	(*m)["includeTeamDiscussions"] = githubv4.Boolean(slices.Contains(cols, "discussions_total_count"))
 	(*m)["includeTeamInvitations"] = githubv4.Boolean(slices.Contains(cols, "invitations_total_count"))
 	(*m)["includeTeamMembers"] = githubv4.Boolean(slices.Contains(cols, "members_total_count"))
 	(*m)["includeTeamProjectsV2"] = githubv4.Boolean(slices.Contains(cols, "projects_v2_total_count"))
@@ -186,14 +185,6 @@ func teamHydrateChildTeamsTotalCount(_ context.Context, _ *plugin.QueryData, h *
 		return nil, err
 	}
 	return teamWithCounts.ChildTeams.TotalCount, nil
-}
-
-func teamHydrateDiscussionsTotalCount(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	teamWithCounts, err := extractTeamFromHydrateItem(h)
-	if err != nil {
-		return nil, err
-	}
-	return teamWithCounts.Discussions.TotalCount, nil
 }
 
 func teamHydrateInvitationsTotalCount(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {


### PR DESCRIPTION
As per https://github.com/turbot/steampipe-plugin-github/issues/530 the `team` table is broken

Please note that I recognise the removal of these fields is a worst-case scenario for consumers of this field. I have not deeply investigated if these fields could be reimplemented, the [changelog upstream](https://docs.github.com/en/graphql/overview/changelog#schema-changes-for-2026-01-08) that introduced the issue only removes the fields and there may be other graph entities that can be hydrated from that would re-enable these fields in the `github_team` table. At current time, it appears all calls to `github_team` are failing due to this however. 

Utilised test sql is:

```sql
select
    combined_slug,
    created_at,
    description,
    id,
    name,
    organization,
    parent_team,
    privacy,
    slug,
    updated_at
from
    github_team
where organization = 'acme'
limit 10
```

Results before applying the changes in this PR:


Error: github: Field 'discussionsUrl' doesn't exist on type 'Team' (SQLSTATE HV000)

```
+---------------+------------+-------------+----+------+--------------+-------------+---------+------+------------+
| combined_slug | created_at | description | id | name | organization | parent_team | privacy | slug | updated_at |
+---------------+------------+-------------+----+------+--------------+-------------+---------+------+------------+
+---------------+------------+-------------+----+------+--------------+-------------+---------+------+------------+
```

After applying changes in this PR: (redacted values)

```
+-----------------------------+---------------------------+--------------------------------------------------+------------+-------------------+--------------+------------------------------------------------------------------------------------------+---------+-------------------+---------------------------+
| combined_slug               | created_at                | description                                      | id         | name              | organization | parent_team                                                                              | privacy | slug              | updated_at                |
+-----------------------------+---------------------------+--------------------------------------------------+------------+-------------------+--------------+------------------------------------------------------------------------------------------+---------+-------------------+---------------------------+
| acme/acme | 2023-11-17T09:06:59+11:00 | ACME                       | 1  | ACME | ACME    | {"id":1,"name":"acme","node_id":"acme","slug":"acme"}      | VISIBLE | acme | 1970-01-01T00:00:00 |
```