### PR TITLE
chore: bump SDK to v6.0.0 + migrate Config access through GetConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.8.2 [2026-05-20]
+
+_Bug fixes_
+
+- Fixed `ExpiredToken`-style errors on long-running queries when Turbot Pipes refreshes GitHub App installation tokens mid-query. The plugin now reads the connection config via the SDK's `GetConfig` accessor (which holds a read lock) on every API call, so in-flight goroutines pick up rotated credentials. ([#<PR>](https://github.com/turbot/steampipe-plugin-github/pull/<PR>))
+
+_Dependencies_
+
+- Upgraded `steampipe-plugin-sdk` to v6.0.0, which adds the `Connection.GetConfig` / `SetConfig` accessors and the per-connection `sync.RWMutex` that the rotation fix above depends on. Plugin builds now require Go 1.26.
+
 ## v1.8.1 [2026-04-03]
 
 _Bug fixes_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 _Bug fixes_
 
-- Fixed `ExpiredToken`-style errors on long-running queries when Turbot Pipes refreshes GitHub App installation tokens mid-query. The plugin now reads the connection config via the SDK's `GetConfig` accessor (which holds a read lock) on every API call, so in-flight goroutines pick up rotated credentials. ([#<PR>](https://github.com/turbot/steampipe-plugin-github/pull/<PR>))
+- Fixed `ExpiredToken`-style errors on long-running queries when Turbot Pipes refreshes GitHub App installation tokens mid-query. The plugin now reads the connection config via the SDK's `GetConfig` accessor (which holds a read lock) on every API call, so in-flight goroutines pick up rotated credentials. ([#546](https://github.com/turbot/steampipe-plugin-github/pull/546))
 
 _Dependencies_
 

--- a/github/branch_utils.go
+++ b/github/branch_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractBranchFromHydrateItem(h *plugin.HydrateData) (models.Branch, error) {

--- a/github/commit_utils.go
+++ b/github/commit_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractCommitFromHydrateItem(h *plugin.HydrateData) (models.Commit, error) {

--- a/github/common_column.go
+++ b/github/common_column.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/shurcooL/githubv4"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/memoize"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/memoize"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func commonColumns(c []*plugin.Column) []*plugin.Column {

--- a/github/community_profile_utils.go
+++ b/github/community_profile_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractCommunityProfileFromHydrateItem(h *plugin.HydrateData) (models.CommunityProfile, error) {

--- a/github/connection_config.go
+++ b/github/connection_config.go
@@ -1,7 +1,7 @@
 package github
 
 import (
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 type githubConfig struct {
@@ -18,9 +18,13 @@ func ConfigInstance() interface{} {
 
 // GetConfig :: retrieve and cast connection config from query data
 func GetConfig(connection *plugin.Connection) githubConfig {
-	if connection == nil || connection.Config == nil {
+	if connection == nil {
 		return githubConfig{}
 	}
-	config, _ := connection.Config.(githubConfig)
+	raw := connection.GetConfig()
+	if raw == nil {
+		return githubConfig{}
+	}
+	config, _ := raw.(githubConfig)
 	return config
 }

--- a/github/errors.go
+++ b/github/errors.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func shouldRetryError(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, err error) bool {

--- a/github/issue_pr_utils.go
+++ b/github/issue_pr_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractPRReviewFromHydrateItem(h *plugin.HydrateData) (models.PullRequestReview, error) {

--- a/github/license_utils.go
+++ b/github/license_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractLicenseFromHydrateItem(h *plugin.HydrateData) (models.License, error) {

--- a/github/organization_utils.go
+++ b/github/organization_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractOrganizationExternalIdentityFromHydrateItem(h *plugin.HydrateData) (models.OrganizationExternalIdentity, error) {

--- a/github/plugin.go
+++ b/github/plugin.go
@@ -3,8 +3,8 @@ package github
 import (
 	"context"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 // Plugin returns this plugin

--- a/github/rate_limit_utils.go
+++ b/github/rate_limit_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractRateLimitFromHydrateItem(h *plugin.HydrateData) (models.BaseRateLimit, error) {

--- a/github/repo_utils.go
+++ b/github/repo_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractRepoEnvironmentFromHydrateItem(h *plugin.HydrateData) (models.Environment, error) {

--- a/github/star_utils.go
+++ b/github/star_utils.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 
 	"github.com/shurcooL/githubv4"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractStarFromHydrateItem(h *plugin.HydrateData) (myStar, error) {

--- a/github/stargazer_utils.go
+++ b/github/stargazer_utils.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 
 	"github.com/shurcooL/githubv4"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractStargazerFromHydrateItem(h *plugin.HydrateData) (Stargazer, error) {

--- a/github/table_github_actions_artifact.go
+++ b/github/table_github_actions_artifact.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubActionsArtifact() *plugin.Table {

--- a/github/table_github_actions_environment_variable.go
+++ b/github/table_github_actions_environment_variable.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubActionsEnvironmentVariable() *plugin.Table {

--- a/github/table_github_actions_organization_variable.go
+++ b/github/table_github_actions_organization_variable.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubActionsOrganizationVariable() *plugin.Table {

--- a/github/table_github_actions_repository_runner.go
+++ b/github/table_github_actions_repository_runner.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubActionsRepositoryRunner() *plugin.Table {

--- a/github/table_github_actions_repository_secret.go
+++ b/github/table_github_actions_repository_secret.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubActionsRepositorySecret() *plugin.Table {

--- a/github/table_github_actions_repository_variable.go
+++ b/github/table_github_actions_repository_variable.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubActionsRepositoryVariable() *plugin.Table {

--- a/github/table_github_actions_repository_workflow_run.go
+++ b/github/table_github_actions_repository_workflow_run.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
-	"github.com/turbot/steampipe-plugin-sdk/v5/query_cache"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/query_cache"
 )
 
 func tableGitHubActionsRepositoryWorkflowRun() *plugin.Table {

--- a/github/table_github_audit_log.go
+++ b/github/table_github_audit_log.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubAuditLog() *plugin.Table {

--- a/github/table_github_blob.go
+++ b/github/table_github_blob.go
@@ -3,9 +3,9 @@ package github
 import (
 	"context"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubBlob() *plugin.Table {

--- a/github/table_github_branch.go
+++ b/github/table_github_branch.go
@@ -6,9 +6,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubBranch() *plugin.Table {

--- a/github/table_github_branch_protection.go
+++ b/github/table_github_branch_protection.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubBranchProtection() *plugin.Table {

--- a/github/table_github_code_owner.go
+++ b/github/table_github_code_owner.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func gitHubCodeOwnerColumns() []*plugin.Column {

--- a/github/table_github_commit.go
+++ b/github/table_github_commit.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func tableGitHubCommit() *plugin.Table {

--- a/github/table_github_community_profile.go
+++ b/github/table_github_community_profile.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubCommunityProfile() *plugin.Table {

--- a/github/table_github_gist.go
+++ b/github/table_github_gist.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubGistColumns() []*plugin.Column {

--- a/github/table_github_gitignore.go
+++ b/github/table_github_gitignore.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func tableGitHubGitignore() *plugin.Table {

--- a/github/table_github_issue.go
+++ b/github/table_github_issue.go
@@ -8,9 +8,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubIssueColumns() []*plugin.Column {

--- a/github/table_github_issue_comment.go
+++ b/github/table_github_issue_comment.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func sharedCommentsColumns() []*plugin.Column {

--- a/github/table_github_license.go
+++ b/github/table_github_license.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func tableGitHubLicense() *plugin.Table {

--- a/github/table_github_my_gist.go
+++ b/github/table_github_my_gist.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func tableGitHubMyGist() *plugin.Table {

--- a/github/table_github_my_issue.go
+++ b/github/table_github_my_issue.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func gitHubMyIssueColumns() []*plugin.Column {

--- a/github/table_github_my_organization.go
+++ b/github/table_github_my_organization.go
@@ -6,7 +6,7 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func tableGitHubMyOrganization() *plugin.Table {

--- a/github/table_github_my_repository.go
+++ b/github/table_github_my_repository.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func tableGitHubMyRepository() *plugin.Table {

--- a/github/table_github_my_star.go
+++ b/github/table_github_my_star.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubMyStar() *plugin.Table {

--- a/github/table_github_my_team.go
+++ b/github/table_github_my_team.go
@@ -6,7 +6,7 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func tableGitHubMyTeam() *plugin.Table {

--- a/github/table_github_organization.go
+++ b/github/table_github_organization.go
@@ -8,9 +8,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func sharedOrganizationColumns() []*plugin.Column {

--- a/github/table_github_organization_collaborators.go
+++ b/github/table_github_organization_collaborators.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubOrganizationCollaborators() []*plugin.Column {

--- a/github/table_github_organization_dependabot_alert.go
+++ b/github/table_github_organization_dependabot_alert.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubDependabotAlertColumns() []*plugin.Column {

--- a/github/table_github_organization_external_identity.go
+++ b/github/table_github_organization_external_identity.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubOrganizationExternalIdentityColumns() []*plugin.Column {

--- a/github/table_github_organization_member.go
+++ b/github/table_github_organization_member.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubOrganizationMemberColumns() []*plugin.Column {

--- a/github/table_github_package.go
+++ b/github/table_github_package.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubPackage() *plugin.Table {

--- a/github/table_github_package_version.go
+++ b/github/table_github_package_version.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubPackageVersion() *plugin.Table {

--- a/github/table_github_pull_request.go
+++ b/github/table_github_pull_request.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func sharedPullRequestColumns() []*plugin.Column {

--- a/github/table_github_pull_request_comment.go
+++ b/github/table_github_pull_request_comment.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func tableGitHubPullRequestComment() *plugin.Table {

--- a/github/table_github_pull_request_review.go
+++ b/github/table_github_pull_request_review.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func pullRequestReviewColumns() []*plugin.Column {

--- a/github/table_github_rate_limit.go
+++ b/github/table_github_rate_limit.go
@@ -3,9 +3,9 @@ package github
 import (
 	"context"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubRateLimit() *plugin.Table {

--- a/github/table_github_rate_limit_graphql.go
+++ b/github/table_github_rate_limit_graphql.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubRateLimitGraphQL() *plugin.Table {

--- a/github/table_github_release.go
+++ b/github/table_github_release.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubRelease() *plugin.Table {

--- a/github/table_github_repository.go
+++ b/github/table_github_repository.go
@@ -7,9 +7,9 @@ import (
 	"github.com/google/go-github/v55/github"
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubRepositoryColumns() []*plugin.Column {

--- a/github/table_github_repository_collaborator.go
+++ b/github/table_github_repository_collaborator.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubRepositoryCollaboratorColumns() []*plugin.Column {

--- a/github/table_github_repository_content.go
+++ b/github/table_github_repository_content.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 //// TABLE DEFINITION

--- a/github/table_github_repository_dependabot_alert.go
+++ b/github/table_github_repository_dependabot_alert.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubRepositoryDependabotAlert() *plugin.Table {

--- a/github/table_github_repository_deployment.go
+++ b/github/table_github_repository_deployment.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubRepositoryDeploymentColumns() []*plugin.Column {

--- a/github/table_github_repository_discussion.go
+++ b/github/table_github_repository_discussion.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubRepositoryDiscussionColumns() []*plugin.Column {

--- a/github/table_github_repository_environment.go
+++ b/github/table_github_repository_environment.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubRepositoryEnvironmentColumns() []*plugin.Column {

--- a/github/table_github_repository_ruleset.go
+++ b/github/table_github_repository_ruleset.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubRepositoryRuleset() *plugin.Table {

--- a/github/table_github_repository_sbom.go
+++ b/github/table_github_repository_sbom.go
@@ -3,9 +3,9 @@ package github
 import (
 	"context"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubRepositorySbom() *plugin.Table {

--- a/github/table_github_repository_vulnerability_alert.go
+++ b/github/table_github_repository_vulnerability_alert.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubRepositoryVulnerabilityAlert() *plugin.Table {

--- a/github/table_github_search_code.go
+++ b/github/table_github_search_code.go
@@ -5,9 +5,9 @@ import (
 	"regexp"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubSearchCode() *plugin.Table {

--- a/github/table_github_search_commit.go
+++ b/github/table_github_search_commit.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubSearchCommit() *plugin.Table {

--- a/github/table_github_search_issue.go
+++ b/github/table_github_search_issue.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func gitHubSearchIssueColumns() []*plugin.Column {

--- a/github/table_github_search_label.go
+++ b/github/table_github_search_label.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubSearchLabel() *plugin.Table {

--- a/github/table_github_search_pull_request.go
+++ b/github/table_github_search_pull_request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func gitHubSearchPullRequestColumns() []*plugin.Column {

--- a/github/table_github_search_repository.go
+++ b/github/table_github_search_repository.go
@@ -5,7 +5,7 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func gitHubSearchRepositoryColumns() []*plugin.Column {

--- a/github/table_github_search_topic.go
+++ b/github/table_github_search_topic.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/google/go-github/v55/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubSearchTopic() *plugin.Table {

--- a/github/table_github_search_user.go
+++ b/github/table_github_search_user.go
@@ -6,9 +6,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubSearchUserColumns() []*plugin.Column {

--- a/github/table_github_stargazer.go
+++ b/github/table_github_stargazer.go
@@ -6,9 +6,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubStargazer() *plugin.Table {

--- a/github/table_github_tag.go
+++ b/github/table_github_tag.go
@@ -7,9 +7,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubTag() *plugin.Table {

--- a/github/table_github_team.go
+++ b/github/table_github_team.go
@@ -7,9 +7,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubTeamColumns() []*plugin.Column {

--- a/github/table_github_team_member.go
+++ b/github/table_github_team_member.go
@@ -7,9 +7,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubTeamMember() *plugin.Table {

--- a/github/table_github_team_repository.go
+++ b/github/table_github_team_repository.go
@@ -7,9 +7,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func gitHubTeamRepositoryColumns() []*plugin.Column {

--- a/github/table_github_traffic_clone_daily.go
+++ b/github/table_github_traffic_clone_daily.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubTrafficCloneDaily() *plugin.Table {

--- a/github/table_github_traffic_clone_weekly.go
+++ b/github/table_github_traffic_clone_weekly.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubTrafficCloneWeekly() *plugin.Table {

--- a/github/table_github_traffic_view_daily.go
+++ b/github/table_github_traffic_view_daily.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubTrafficViewDaily() *plugin.Table {

--- a/github/table_github_traffic_view_weekly.go
+++ b/github/table_github_traffic_view_weekly.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubTrafficViewWeekly() *plugin.Table {

--- a/github/table_github_tree.go
+++ b/github/table_github_tree.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/google/go-github/v55/github"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubTree() *plugin.Table {

--- a/github/table_github_user.go
+++ b/github/table_github_user.go
@@ -7,9 +7,9 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubUser() *plugin.Table {

--- a/github/table_github_workflow.go
+++ b/github/table_github_workflow.go
@@ -11,9 +11,9 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/go-github/v55/github"
 	"github.com/turbot/go-kit/types"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 func tableGitHubWorkflow() *plugin.Table {

--- a/github/tag_utils.go
+++ b/github/tag_utils.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 
 	"github.com/shurcooL/githubv4"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractTagFromHydrateItem(h *plugin.HydrateData) (tagRow, error) {

--- a/github/team_utils.go
+++ b/github/team_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractTeamFromHydrateItem(h *plugin.HydrateData) (models.TeamWithCounts, error) {

--- a/github/user_utils.go
+++ b/github/user_utils.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/shurcooL/githubv4"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func extractUserFromHydrateItem(h *plugin.HydrateData) (models.UserWithCounts, error) {

--- a/github/utils.go
+++ b/github/utils.go
@@ -12,14 +12,14 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation"
 	"github.com/turbot/steampipe-plugin-github/github/models"
-	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
 
 	"github.com/google/go-github/v55/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
 )
 
 var allowedPersonalAccessTokenTokenPrefixes = []string{

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-github/v55 v55.0.0
 	github.com/shurcooL/githubv4 v0.0.0-20231126234147-1cffa1f02456
 	github.com/turbot/go-kit v1.1.0
-	github.com/turbot/steampipe-plugin-sdk/v5 v5.14.0
+	github.com/turbot/steampipe-plugin-sdk/v6 v6.0.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/oauth2 v0.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1085,8 +1085,8 @@ github.com/tkrajina/go-reflector v0.5.6 h1:hKQ0gyocG7vgMD2M3dRlYN6WBBOmdoOzJ6njQ
 github.com/tkrajina/go-reflector v0.5.6/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/turbot/go-kit v1.1.0 h1:2gW+MFDJD+mN41GcvhAajTrwR8HgN9KKJ8HnYwPGTV0=
 github.com/turbot/go-kit v1.1.0/go.mod h1:1xmRuQ0cn/10QUMNLNOAFIqN8P6Rz5s3VLT8mkN3nF8=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.14.0 h1:CyufzeM2BMbA2nJRuujucchp9NZ6BEeYA2phhdMXsW4=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.14.0/go.mod h1:VHKUVPx29JEHXjuY9Kj/fdabceHdGQB1kaH4Dik/XY8=
+github.com/turbot/steampipe-plugin-sdk/v6 v6.0.0 h1:Zm0UA4JJ20X8qoDLSgRSMKrfBvNdqJcJ47A6HOX7G2o=
+github.com/turbot/steampipe-plugin-sdk/v6 v6.0.0/go.mod h1:CIMDhrEuWC9+x+y1fOBdWnCHFCDHKBfob7aNOlNoJbY=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/turbot/steampipe-plugin-github/github"
-	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
 )
 
 func main() {


### PR DESCRIPTION
Migrates `connection.Config` direct reads to `connection.GetConfig()` per `steampipe-plugin-sdk` v6.0.0 (see [steampipe-plugin-sdk#938](https://github.com/turbot/steampipe-plugin-sdk/pull/938)). GitHub-side rollout of the same fix that landed for AWS in [steampipe-plugin-aws#2756](https://github.com/turbot/steampipe-plugin-aws/pull/2756). The github plugin had the highest-traffic uncached `connection.Config` read site of any plugin sampled (`appendUserInteractionAbilityForIssue` in `user_utils.go`, called per-query on 7+ tables) — this PR closes that race surface. Build, vet, test, and `go test -race` all green.